### PR TITLE
Add check for readonly property-ignore them

### DIFF
--- a/src/Angie.Core/Angie.cs
+++ b/src/Angie.Core/Angie.cs
@@ -32,7 +32,7 @@ namespace Angela.Core
             {
                 foreach (var property in typeof(T).GetProperties())
                 {
-                    if (!Chastity.HasValue<T>(instance, property))
+                    if (!Chastity.HasValue<T>(instance, property) && property.CanWrite)
                     {
                         SetPropertyValue<T>(instance, property);
                     }

--- a/tests/AngieTests.cs
+++ b/tests/AngieTests.cs
@@ -434,5 +434,12 @@ namespace Angela.Tests
             }
             
         }
+
+        [Test]
+        public void ShouldIgnoreUnsettableProperties()
+        {
+            var list = Angie.Configure<BlogCommenter>()
+                .MakeList<BlogCommenter>();
+        }
     }
 }

--- a/tests/BlogPost.cs
+++ b/tests/BlogPost.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -19,6 +20,14 @@ namespace Angela.Tests
         public string Comment { get; set; }
         public string Username { get; set; }
         public DateTime CommentDate { get; set; }
+    }
+    
+    internal class BlogCommenter
+    {
+        public int BlogCommenterId { get; set; }
+        public string NullName { get { return null; } }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
     }
 
 }


### PR DESCRIPTION
When I was looking at the possibility of adding method setting, I noticed that AngelaSmith tries to set properties which are not actually writable. This fix makes it ignore nonwritable properties. This stands alone, so I'm submitting it separately from the much more complicate method-setting feature. (BTW, the method write thing is just about done and is MUCH bigger than this, it just needs a bit of polishing before the pull request)
