### PR TITLE
Added RelativeSearchPath to ResetFillers

### DIFF
--- a/src/Angie.Core/FillerManager.cs
+++ b/src/Angie.Core/FillerManager.cs
@@ -30,6 +30,10 @@ namespace Angela.Core
             {
                 AggregateCatalog catalog = new AggregateCatalog();
                 catalog.Catalogs.Add(new DirectoryCatalog(AppDomain.CurrentDomain.BaseDirectory));
+                if (!String.IsNullOrEmpty(AppDomain.CurrentDomain.RelativeSearchPath))
+                {
+                    catalog.Catalogs.Add(new DirectoryCatalog(AppDomain.CurrentDomain.RelativeSearchPath));
+                }
                 catalog.Catalogs.Add(new DirectoryCatalog(AppDomain.CurrentDomain.BaseDirectory, "*.exe"));
                 CompositionContainer container = new CompositionContainer(catalog);
                 container.ComposeParts(this);


### PR DESCRIPTION
Added the RelativeSearchPath directory (if available) to the catalogs in
ResetFillers, in order to load fillers from the bin directory of a web
application.
