### PR TITLE
Removed unused package references

### DIFF
--- a/GenFu/GenFu/project.json
+++ b/GenFu/GenFu/project.json
@@ -1,39 +1,30 @@
 ﻿{
-  "version": "1.0.1",
-  "authors": [
-    "misterjames",
-    "dpaquette",
-    "stimms"
-  ],
-  "description": "GenFu is a library you can use to generate realistic test data. It is composed of several property fillers that can populate commonly named properties through reflection using an internal database of values or randomly created data. You can override any of the fillers and give GenFu hints on how to fill properties.",
-  "dependencies": {
-    "System.Linq.Expressions": "4.0.0-beta-*"
-  },
+    "version": "1.0.1",
+    "authors": [
+        "misterjames",
+        "dpaquette",
+        "stimms"
+    ],
+    "description": "GenFu is a library you can use to generate realistic test data. It is composed of several property fillers that can populate commonly named properties through reflection using an internal database of values or randomly created data. You can override any of the fillers and give GenFu hints on how to fill properties.",
+    "dependencies": {
+        "System.Linq": "4.0.0-beta-*",
+        "System.Linq.Expressions": "4.0.0-beta-*",
+        "System.Reflection": "4.0.0-beta-*",
+        "System.Reflection.TypeExtensions": "4.0.0-beta-*",
+        "System.Runtime": "4.0.20-beta-*",
+        "System.Runtime.Extensions": "4.0.10-beta-*",
+        "System.IO.FileSystem": "4.0.0-beta-*",
+        "System.Globalization": "4.0.10-beta-*",
+        "System.Text.RegularExpressions": "4.0.10-beta-*"
+    },
   "frameworks": {
     "aspnet50": {
       "dependencies": {
-        "Microsoft.Composition": "1.0.27"
+
       }
     },
     "aspnetcore50": {
-      "dependencies": {
-        "System.Collections": "4.0.10-beta-*",
-        "System.Collections.Concurrent": "4.0.0-beta-*",
-        "System.ComponentModel": "4.0.0-beta-*",
-        "System.Linq": "4.0.0-beta-*",
-        "System.Reflection": "4.0.0-beta-*",
-        "System.Reflection.TypeExtensions": "4.0.0-beta-*",
-        "System.Reflection.Extensions": "4.0.0-beta-*",
-        "System.Reflection.Primitives": "4.0.0-beta-*",
-        "System.Runtime": "4.0.20-beta-*",
-        "System.Runtime.InteropServices": "4.0.10.0",
-        "System.Runtime.Extensions": "4.0.10-beta-*",
-        "System.Threading": "4.0.0-beta-*",
-        "System.Threading.Tasks": "4.0.10-beta-*",
-        "System.IO.FileSystem": "4.0.0-beta-*",
-        "System.IO.FileSystem.Primitives": "4.0.0-beta-*",
-        "System.Globalization": "4.0.10-beta-*",
-        "System.Text.RegularExpressions": "4.0.10-beta-*"
+      "dependencies": {               
       }
     }
   },


### PR DESCRIPTION
Our package references were a little messy. Wanted to clean that up to simplify the nuget package and want to try targeting net45 after this is merged.
