### PR TITLE
Removing space prefix

### DIFF
--- a/src/GenFu/Resources/USAStateNames.txt
+++ b/src/GenFu/Resources/USAStateNames.txt
@@ -1,56 +1,56 @@
-﻿ California
- Texas
- New York
- Florida
- Illinois
- Pennsylvania
- Ohio
- Georgia
- Michigan
- North Carolina
- New Jersey
- Virginia
- Washington
- Massachusetts
- Arizona
- Indiana
- Tennessee
- Missouri
- Maryland
- Wisconsin
- Minnesota
- Colorado
- Alabama
- South Carolina
- Louisiana
- Kentucky
- Oregon
- Oklahoma
- Puerto Rico
- Connecticut
- Iowa
- Mississippi
- Arkansas
- Kansas
- Utah
- Nevada
- New Mexico
- Nebraska
- West Virginia
- Idaho
- Hawaii
- Maine
- New Hampshire
- Rhode Island
- Montana
- Delaware
- South Dakota
- Alaska
- North Dakota
- District of Columbia
- Vermont
- Wyoming
- Guam
- U.S. Virgin Islands
- American Samoa
- Northern Mariana Islands
+California
+Texas
+New York
+Florida
+Illinois
+Pennsylvania
+Ohio
+Georgia
+Michigan
+North Carolina
+New Jersey
+Virginia
+Washington
+Massachusetts
+Arizona
+Indiana
+Tennessee
+Missouri
+Maryland
+Wisconsin
+Minnesota
+Colorado
+Alabama
+South Carolina
+Louisiana
+Kentucky
+Oregon
+Oklahoma
+Puerto Rico
+Connecticut
+Iowa
+Mississippi
+Arkansas
+Kansas
+Utah
+Nevada
+New Mexico
+Nebraska
+West Virginia
+Idaho
+Hawaii
+Maine
+New Hampshire
+Rhode Island
+Montana
+Delaware
+South Dakota
+Alaska
+North Dakota
+District of Columbia
+Vermont
+Wyoming
+Guam
+U.S. Virgin Islands
+American Samoa
+Northern Mariana Islands


### PR DESCRIPTION
US states are all prefixed with at least one space (e.g., `" Iowa"`). This PR removes those spaces.