### PR TITLE
Set nullables #13

### DIFF
--- a/src/GenFu/DefaultValueChecker.cs
+++ b/src/GenFu/DefaultValueChecker.cs
@@ -8,7 +8,14 @@ namespace GenFu
         internal static bool HasValue(object instance, PropertyInfo property)
         {
             var value = property.GetValue(instance,null);
-            bool valueSet = false;           
+            bool valueSet = false;
+
+            // Support Nullable items
+            if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return value != null;
+            }
+
             switch (property.PropertyType.Name.ToLower())
             {
                 case "int32":

--- a/src/GenFu/FillerManager.cs
+++ b/src/GenFu/FillerManager.cs
@@ -34,8 +34,11 @@ namespace GenFu
 
                 _propertyFillers.Add(new CookingFiller.IngredientFiller());
 
-                _propertyFillers.Add(new DateTimeFiller());
-                _propertyFillers.Add(new DateTimeNullableFiller());
+                {
+                    DateTimeNullableFiller DateTimeNullableFiller = new DateTimeAdapterFiller<DateTime?>();
+                    _propertyFillers.Add(new DateTimeFiller());
+                    _propertyFillers.Add(DateTimeNullableFiller);
+                }
 
                 _propertyFillers.Add(new BirthDateFiller());
                 _propertyFillers.Add(new GuidFiller());

--- a/src/GenFu/FillerManager.cs
+++ b/src/GenFu/FillerManager.cs
@@ -35,6 +35,8 @@ namespace GenFu
                 _propertyFillers.Add(new CookingFiller.IngredientFiller());
 
                 _propertyFillers.Add(new DateTimeFiller());
+                _propertyFillers.Add(new DateTimeNullableFiller());
+
                 _propertyFillers.Add(new BirthDateFiller());
                 _propertyFillers.Add(new GuidFiller());
                 _propertyFillers.Add(new ArticleTitleFiller());

--- a/src/GenFu/Fillers/DateTimeAdapterFiller.cs
+++ b/src/GenFu/Fillers/DateTimeAdapterFiller.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace GenFu.Fillers
+{
+    public class DateTimeAdapterFiller<T> : DateTimeNullableFiller
+    {
+        DateTimeFiller dateTimeFiller = new DateTimeFiller();
+        private Random rand = new Random();
+
+        public override object GetValue(object instance)
+        {
+            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                if (this.SeedPercentage < rand.NextDouble())
+                {
+                    return null;
+                }
+                else
+                {
+                    return dateTimeFiller.GetValue(instance);
+                }
+            }
+
+            return dateTimeFiller.GetValue(instance);
+        }
+    }
+}

--- a/src/GenFu/Fillers/DateTimeNullableFillers.cs
+++ b/src/GenFu/Fillers/DateTimeNullableFillers.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace GenFu
+{
+    public class DateTimeNullableFiller : PropertyFiller<DateTime?>
+    {
+        private Random _random = new Random();
+
+        public DateTime Min { get; set; }
+        public DateTime Max { get; set; }
+        public int SeedMin { get; set; }
+        public int SeedMax { get; set; }
+
+        public DateTimeNullableFiller()
+            : base(new[] { "object" }, new[] { "*" }, true)
+        {
+        }
+
+        public override object GetValue(object instance)
+        {
+            var nullSeed = _random.Next(SeedMax);
+            if (nullSeed < SeedMin)
+            {
+                return null;
+            }
+
+            int totalDays = (Max - Min).Days;
+            int randomDays = _random.Next(totalDays);
+            int seconds = _random.Next(24 * 60 * 60);
+            return Min.AddDays(randomDays).AddSeconds(seconds);
+        }
+    }
+}

--- a/src/GenFu/Fillers/DateTimeNullableFillers.cs
+++ b/src/GenFu/Fillers/DateTimeNullableFillers.cs
@@ -8,8 +8,7 @@ namespace GenFu
 
         public DateTime Min { get; set; }
         public DateTime Max { get; set; }
-        public int SeedMin { get; set; }
-        public int SeedMax { get; set; }
+        public double SeedPercentage { get; set; }
 
         public DateTimeNullableFiller()
             : base(new[] { "object" }, new[] { "*" }, true)
@@ -18,16 +17,7 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            var nullSeed = _random.Next(SeedMax);
-            if (nullSeed < SeedMin)
-            {
-                return null;
-            }
-
-            int totalDays = (Max - Min).Days;
-            int randomDays = _random.Next(totalDays);
-            int seconds = _random.Next(24 * 60 * 60);
-            return Min.AddDays(randomDays).AddSeconds(seconds);
+            return null;
         }
     }
 }

--- a/src/GenFu/GenFu.cs
+++ b/src/GenFu/GenFu.cs
@@ -151,6 +151,8 @@ namespace GenFu
             public static DateTime MIN_DATETIME = DateTime.Now.AddYears(-30);
             public static DateTime MAX_DATETIME = DateTime.Now.AddYears(30);
             
+            public static int MIN_SEED = 2;
+            public static int MAX_SEED = 5;
 
             public const string FILE_DOMAIN_NAMES = "DomainNames";
             public const string FILE_FIRST_NAMES = "FirstNames";

--- a/src/GenFu/GenFu.cs
+++ b/src/GenFu/GenFu.cs
@@ -151,8 +151,7 @@ namespace GenFu
             public static DateTime MIN_DATETIME = DateTime.Now.AddYears(-30);
             public static DateTime MAX_DATETIME = DateTime.Now.AddYears(30);
             
-            public static int MIN_SEED = 2;
-            public static int MAX_SEED = 5;
+            public static double SEED_PERCENTAGE = 0.2;
 
             public const string FILE_DOMAIN_NAMES = "DomainNames";
             public const string FILE_FIRST_NAMES = "FirstNames";

--- a/src/GenFu/GenFuFluent.cs
+++ b/src/GenFu/GenFuFluent.cs
@@ -72,6 +72,9 @@ namespace GenFu
             defaults.SetMinDateTime(GenFu.Defaults.MIN_DATETIME);
             defaults.SetMaxDateTime(GenFu.Defaults.MAX_DATETIME);
 
+            defaults.SetMinSeed(GenFu.Defaults.MIN_SEED);
+            defaults.SetMaxSeed(GenFu.Defaults.MAX_SEED);
+
             ResourceLoader.PropertyFillers.Clear();
         }
 

--- a/src/GenFu/GenFuFluent.cs
+++ b/src/GenFu/GenFuFluent.cs
@@ -72,8 +72,7 @@ namespace GenFu
             defaults.SetMinDateTime(GenFu.Defaults.MIN_DATETIME);
             defaults.SetMaxDateTime(GenFu.Defaults.MAX_DATETIME);
 
-            defaults.SetMinSeed(GenFu.Defaults.MIN_SEED);
-            defaults.SetMaxSeed(GenFu.Defaults.MAX_SEED);
+            defaults.SetSeedPercentage(GenFu.Defaults.SEED_PERCENTAGE);
 
             ResourceLoader.PropertyFillers.Clear();
         }

--- a/src/GenFu/GenericFillerDefaults.cs
+++ b/src/GenFu/GenericFillerDefaults.cs
@@ -52,12 +52,30 @@ namespace GenFu
         {
             DateTimeFiller dateTimeFiller = _fillerManager.GetGenericFiller<DateTime, DateTimeFiller>();
             dateTimeFiller.Min = minValue;
+
+            DateTimeNullableFiller dateTimeNullableFiller = _fillerManager.GetGenericFiller<DateTime?, DateTimeNullableFiller>();
+            dateTimeNullableFiller.Min = minValue;
         }
 
         public void SetMaxDateTime(DateTime maxValue)
         {
             DateTimeFiller dateTimeFiller = _fillerManager.GetGenericFiller<DateTime, DateTimeFiller>();
             dateTimeFiller.Max = maxValue;
+
+            DateTimeNullableFiller dateTimeNullableFiller = _fillerManager.GetGenericFiller<DateTime?, DateTimeNullableFiller>();
+            dateTimeNullableFiller.Max = maxValue;
+        }
+
+        public void SetMinSeed(int minValue)
+        {
+            DateTimeNullableFiller dateTimeNullableFiller = _fillerManager.GetGenericFiller<DateTime?, DateTimeNullableFiller>();
+            dateTimeNullableFiller.SeedMin = minValue;
+        }
+
+        public void SetMaxSeed(int maxValue)
+        {
+            DateTimeNullableFiller dateTimeNullableFiller = _fillerManager.GetGenericFiller<DateTime?, DateTimeNullableFiller>();
+            dateTimeNullableFiller.SeedMax = maxValue;
         }
 
         public DateTime GetMinDateTime()

--- a/src/GenFu/GenericFillerDefaults.cs
+++ b/src/GenFu/GenericFillerDefaults.cs
@@ -66,16 +66,10 @@ namespace GenFu
             dateTimeNullableFiller.Max = maxValue;
         }
 
-        public void SetMinSeed(int minValue)
+        public void SetSeedPercentage(double value)
         {
             DateTimeNullableFiller dateTimeNullableFiller = _fillerManager.GetGenericFiller<DateTime?, DateTimeNullableFiller>();
-            dateTimeNullableFiller.SeedMin = minValue;
-        }
-
-        public void SetMaxSeed(int maxValue)
-        {
-            DateTimeNullableFiller dateTimeNullableFiller = _fillerManager.GetGenericFiller<DateTime?, DateTimeNullableFiller>();
-            dateTimeNullableFiller.SeedMax = maxValue;
+            dateTimeNullableFiller.SeedPercentage = value;
         }
 
         public DateTime GetMinDateTime()

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -452,8 +452,7 @@ namespace GenFu.Tests
         public void NullableDateWillGetRandomNullSeed()
         {
             // Allow average 20% of collection to be Null 
-            GenFu.Defaults.MAX_SEED = 10;
-            GenFu.Defaults.MIN_SEED = 2;
+            GenFu.Defaults.SEED_PERCENTAGE = 0.2;
 
             var dates = new List<DateTime?>();
             for(int x = 0; x<100; x++)
@@ -493,8 +492,7 @@ namespace GenFu.Tests
         public void NullableDateWillStayNull()
         {
             // Update Seed so the value is always NULL
-            GenFu.Defaults.MAX_SEED = 0;
-            GenFu.Defaults.MIN_SEED = 10;
+            GenFu.Defaults.SEED_PERCENTAGE = 0;
 
             A.Reset();
             var person = A.New(new Person() { DateOfDeath = null });

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -447,5 +447,43 @@ namespace GenFu.Tests
             Assert.True(!string.IsNullOrEmpty(person.GetMiddleName()));
             Assert.Equal(expected, person.GetMiddleName());
         }
+
+        [Fact]
+        public void NullableDateWillGetRandomNullSeed()
+        {
+
+            var dates = new List<DateTime?>();
+            for(int x = 0; x<100; x++)
+            {
+                A.Reset();
+                var person = A.New(new Person());
+                dates.Add(person.DateOfDeath);
+            }
+
+            int nullItems = dates.Where(x => x == null).Count();
+            int notNullItems = dates.Where(x => x != null).Count();
+
+            // Should contain mix of Nulls and set values
+            Assert.True(nullItems > 0);
+            Assert.True(notNullItems > 0);
+        }
+
+        [Fact(Skip ="Not yet supported but should be")]
+        public void IntIsPopulatedIfNullable()
+        {
+            A.Reset();
+            var person = A.New(new Person());
+
+            Assert.NotEqual(null, person.NumberOfCats);
+        }
+
+        [Fact]
+        public void StringIsPopulatedIfNullable()
+        {
+            A.Reset();
+            var person = A.New(new Person() { FirstName = null } );
+
+            Assert.NotNull(person.FirstName);
+        }
     }
 }

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -451,6 +451,9 @@ namespace GenFu.Tests
         [Fact]
         public void NullableDateWillGetRandomNullSeed()
         {
+            // Allow average 20% of collection to be Null 
+            GenFu.Defaults.MAX_SEED = 10;
+            GenFu.Defaults.MIN_SEED = 2;
 
             var dates = new List<DateTime?>();
             for(int x = 0; x<100; x++)
@@ -484,6 +487,19 @@ namespace GenFu.Tests
             var person = A.New(new Person() { FirstName = null } );
 
             Assert.NotNull(person.FirstName);
+        }
+
+        [Fact]
+        public void NullableDateWillStayNull()
+        {
+            // Update Seed so the value is always NULL
+            GenFu.Defaults.MAX_SEED = 0;
+            GenFu.Defaults.MIN_SEED = 10;
+
+            A.Reset();
+            var person = A.New(new Person() { DateOfDeath = null });
+
+            Assert.Null(person.DateOfDeath);
         }
     }
 }

--- a/tests/GenFu.Tests/TestEntities/Person.cs
+++ b/tests/GenFu.Tests/TestEntities/Person.cs
@@ -26,7 +26,7 @@ namespace GenFu.Tests
 
 
         // emailaddress EmailAddress email_address
-        public String EmailAddress { get; set; }
+        public string EmailAddress { get; set; }
 
         public string Twitter { get; set; }
 

--- a/tests/GenFu.Tests/TestEntities/Person.cs
+++ b/tests/GenFu.Tests/TestEntities/Person.cs
@@ -26,7 +26,7 @@ namespace GenFu.Tests
 
 
         // emailaddress EmailAddress email_address
-        public string EmailAddress { get; set; }
+        public String EmailAddress { get; set; }
 
         public string Twitter { get; set; }
 
@@ -48,5 +48,8 @@ namespace GenFu.Tests
             return _middleName;
         }
 
+        public DateTime? DateOfDeath { get; set; }
+
+        public int? NumberOfCats { get; set; }
     }
 }


### PR DESCRIPTION
Allow Nullable datetime properties to be generated. This uses a Seed value that can be controlled by the Defaults within GenFu. This means that 20% of values can be set to Null whilst the remaining 80% are given a value. I have re-used the same Min/Max date values as the standard DateTimeFilter as I did not see the point in creating two new Defaults.
This is coded to solve "Set nullables #13" for DateTime only. Other types (Int?) are still outstanding and Unit Test is updated to reflect this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/misterjames/genfu/53)
<!-- Reviewable:end -->
