### PR TITLE
Fix IsGenericType compile error

### DIFF
--- a/src/GenFu/DefaultValueChecker.cs
+++ b/src/GenFu/DefaultValueChecker.cs
@@ -11,7 +11,7 @@ namespace GenFu
             bool valueSet = false;
 
             // Support Nullable items
-            if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (property.PropertyType.GetTypeInfo().IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 return value != null;
             }

--- a/src/GenFu/Fillers/DateTimeAdapterFiller.cs
+++ b/src/GenFu/Fillers/DateTimeAdapterFiller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace GenFu.Fillers
 {
@@ -9,7 +10,7 @@ namespace GenFu.Fillers
 
         public override object GetValue(object instance)
         {
-            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (typeof(T).GetTypeInfo().IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 if (this.SeedPercentage < rand.NextDouble())
                 {


### PR DESCRIPTION
When I try to build the solution, I get the following error:

```
'Type' does not contain a definition for 'IsGenericType' and no extension method 'IsGenericType' accepting a first argument of type 'Type' could be found (are you missing a using directive or an assembly reference?)
```

There are two locations where this error occurs:

1. DefaultValueChecker.cs
2. DateTimeAdapterFiller.cs

After some Googling, I found the [following SO question](http://stackoverflow.com/questions/32623013/how-can-i-determine-whether-a-property-is-a-generic-type-in-dnx-core-5-0). It suggested that to get it working, a call to `GetTypeInfo()` should be appended to the type. I tried that for both problematic calls and indeed the problem was fixed.