### PR TITLE
Remove magic strings (fixes #54)

### DIFF
--- a/src/GenFu/DefaultValueChecker.cs
+++ b/src/GenFu/DefaultValueChecker.cs
@@ -8,34 +8,29 @@ namespace GenFu
         internal static bool HasValue(object instance, PropertyInfo property)
         {
             var value = property.GetValue(instance,null);
-            bool valueSet = false;
-
+            
             // Support Nullable items
             if (property.PropertyType.GetTypeInfo().IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 return value != null;
             }
 
-            switch (property.PropertyType.Name.ToLower())
+            if (property.PropertyType == typeof(int))
             {
-                case "int32":
-                    if ((Int32)value != default(Int32))
-                        valueSet = true;
-                    break;
-                case "string":
-                    if ((string)value != default(string))
-                        valueSet = true;
-                    break;
-                case "datetime":
-                    if ((DateTime)value != default(DateTime))
-                        valueSet = true;
-                    break;
-                default:
-                    break;
+                return (int)value != default(int);
             }
 
-            return valueSet;
-        }
+            if (property.PropertyType == typeof(string))
+            {
+                return (string)value != default(string);
+            }
 
+            if (property.PropertyType == typeof(DateTime))
+            {
+                return (DateTime)value != default(DateTime);
+            }
+
+            return false;
+        }
     }
 }

--- a/src/GenFu/DefaultValueChecker.cs
+++ b/src/GenFu/DefaultValueChecker.cs
@@ -11,7 +11,7 @@ namespace GenFu
             bool valueSet = false;
 
             // Support Nullable items
-            if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (property.PropertyType.GetTypeInfo().IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 return value != null;
             }

--- a/src/GenFu/Fillers/DateTimeAdapterFiller.cs
+++ b/src/GenFu/Fillers/DateTimeAdapterFiller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace GenFu.Fillers
 {
@@ -9,7 +10,7 @@ namespace GenFu.Fillers
 
         public override object GetValue(object instance)
         {
-            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (typeof(T).GetTypeInfo().IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 if (this.SeedPercentage < rand.NextDouble())
                 {


### PR DESCRIPTION
This PR replaces the magic type strings used in `DefaultValueChecker`. 

Note that to get things to build, I had to submit another PR (#56). This PR is thus dependent on #56.