### PR TITLE
Fix fillers for guids

### DIFF
--- a/src/GenFu/DefaultValueChecker.cs
+++ b/src/GenFu/DefaultValueChecker.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace GenFu
@@ -25,6 +24,8 @@ namespace GenFu
             else if (property.PropertyType == typeof(decimal) && (decimal)value == default(decimal))
                 return false;
             else if (property.PropertyType == typeof(float) && (float)value == default(float))
+                return false;
+            else if (property.PropertyType == typeof(Guid) && (Guid)value == default(Guid))
                 return false;
             else if (property.PropertyType == typeof(long) && (long)value == default(long))
                 return false;

--- a/src/GenFu/Fillers/GuidFiller.cs
+++ b/src/GenFu/Fillers/GuidFiller.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GenFu.Fillers
 {

--- a/src/GenFu/GenFu.cs
+++ b/src/GenFu/GenFu.cs
@@ -46,6 +46,10 @@ namespace GenFu
             if (instance != null)
             {
                 var type = instance.GetType();
+                if (type.FullName == "System.Guid")
+                {
+                    instance = Guid.NewGuid();
+                }
                 foreach (var property in type.GetTypeInfo().GetAllProperties())
                 {
                     if (!DefaultValueChecker.HasValue(instance, property) && property.CanWrite)
@@ -60,7 +64,6 @@ namespace GenFu
                         CallSetterMethod(instance, method);
                     }
                 }
-
             }
             return instance;
         }

--- a/tests/GenFu.Tests/TestEntities/AuditEntry.cs
+++ b/tests/GenFu.Tests/TestEntities/AuditEntry.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace GenFu.Tests.TestEntities
+{
+    public class AuditEntry
+    {
+        public Guid AuditId { get; set; }
+        public DateTime AuditDate { get; set; }
+        public string UserName { get; set; }
+    }
+}

--- a/tests/GenFu.Tests/When_filling_guids.cs
+++ b/tests/GenFu.Tests/When_filling_guids.cs
@@ -1,0 +1,30 @@
+﻿using GenFu.Tests.TestEntities;
+using System;
+using Xunit;
+
+namespace GenFu.Tests
+{
+    public class When_filling_guids
+    {
+        [Fact]
+        public void FillGuidWithNonDefault()
+        {
+            var guid = A.New<Guid>().ToString();
+            var guidDefault = new Guid().ToString();
+
+            Assert.NotEqual(guidDefault, guid);
+
+        }
+
+        [Fact]
+        public void FillGuidAsPropertyWithNonDefault()
+        {
+            var guid = A.New<AuditEntry>().AuditId.ToString();
+            var guidDefault = new Guid().ToString();
+
+            Assert.NotEqual(guidDefault, guid);
+
+        }
+
+    }
+}

--- a/tests/GenFu.Tests/When_getting_a_generic_filler.cs
+++ b/tests/GenFu.Tests/When_getting_a_generic_filler.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using GenFu;
-using System.Linq;
+﻿using GenFu.Fillers;
+using System;
 using Xunit;
-using System.Collections.Generic;
 
-namespace GenFu.Tests { 
+namespace GenFu.Tests
+{
 
     public class When_getting_a_generic_filler
     {
@@ -34,6 +33,13 @@ namespace GenFu.Tests {
         {
             var manager = new global::GenFu.FillerManager();
             Assert.NotNull(manager.GetGenericFiller<decimal, DecimalFiller>());
+        }
+
+        [Fact]
+        public void A_guid_filler_is_returned()
+        {
+            var manager = new global::GenFu.FillerManager();
+            Assert.NotNull(manager.GetGenericFiller<Guid, GuidFiller>());
         }
     }
 }


### PR DESCRIPTION
`Guid`s are a special case because when you new one up it appears to have a valid value. This PR changes GenFu to do an explicit type check (for new requests off the `Guid` type) and adds a check for the default value when initializing a property of type `Guid`.

Fixes #75 