### PR TITLE
Added image placeholder filler

### DIFF
--- a/src/GenFu/Fillers/ImgFormat.cs
+++ b/src/GenFu/Fillers/ImgFormat.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GenFu.Fillers
+{
+    public enum ImgFormat
+    {
+        PNG,
+        JPG,
+        JPEG,
+        GIF
+    }
+}

--- a/src/GenFu/Fillers/StringFillerExtensions.cs
+++ b/src/GenFu/Fillers/StringFillerExtensions.cs
@@ -1,7 +1,9 @@
+using GenFu.Fillers;
 using GenFu.ValueGenerators.Geospatial;
 using GenFu.ValueGenerators.People;
 using System;
 using System.Text;
+using GenFu.Utilities;
 
 namespace GenFu
 {
@@ -246,6 +248,31 @@ namespace GenFu
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
+        #endregion
+
+        #region Placeholder Image
+
+        public static GenFuConfigurator<T> AsPlaceholderImage<T>(this GenFuStringConfigurator<T> configurator,
+            int width, int height,
+            string text = null,
+            string backgroundColor = null,
+            string textColor = null,
+            object htmlAttributes = null,
+            ImgFormat format = ImgFormat.GIF) where T : new()
+        {
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), 
+                () => new StringBuilder()
+                .Append("http://placehold.it/")
+                .Append($"{width}x{height}")
+                .AppendWhen($".{format}", format != ImgFormat.GIF)
+                .AppendWhen($"/{backgroundColor}", !string.IsNullOrWhiteSpace(backgroundColor))
+                .AppendWhen($"/{textColor}", !string.IsNullOrWhiteSpace(textColor))
+                .AppendWhen($"?text={text}", !string.IsNullOrWhiteSpace(text))
+                .ToString());
+            configurator.Maggie.RegisterFiller(filler);
+            return configurator;
+        }
+
         #endregion
 
     }

--- a/src/GenFu/Utilities/StringBuilderExtensions.cs
+++ b/src/GenFu/Utilities/StringBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace GenFu.Utilities
         /// <param name="value">String to append.</param>
         /// <param name="predicate">Predicate</param>
         /// <returns></returns>
-        public static StringBuilder AppendWhen(this StringBuilder sb, string value, Func<bool> predicate) => predicate() ? sb.Append(value) : sb;
+        public static StringBuilder AppendWhen(this StringBuilder sb, string value, bool predicate) => predicate ? sb.Append(value) : sb;
 
         /// <summary>
         /// Repeats a string builder operation for n times.

--- a/src/GenFu/ValueGenerators/Lorem/Lorem.cs
+++ b/src/GenFu/ValueGenerators/Lorem/Lorem.cs
@@ -16,7 +16,7 @@ namespace GenFu.ValueGenerators.Lorem
                .BuildFor(numberOfWords, (words, i) =>
                   words
                     .Append(GenerateWord())
-                    .AppendWhen(",", () => commaPosition > 0 && commaPosition == i)
+                    .AppendWhen(",", commaPosition > 0 && commaPosition == i)
                     .Append(" "))
                .ToString()
                .TrimEnd(' ');

--- a/tests/GenFu.Tests/ImageUrlTests.cs
+++ b/tests/GenFu.Tests/ImageUrlTests.cs
@@ -1,0 +1,104 @@
+﻿using GenFu.Fillers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GenFu.Tests
+{
+    class Profile : Person
+    {
+        public string AvatarUrl { get; set; }
+    }
+
+    public class ImageUrlTests
+    {
+        [Fact]
+        public void ShouldCreateImgTagUsingWidthAndHeight()
+        {
+            
+            A.Configure<Profile>()
+                .Fill(p => p.AvatarUrl)
+                .AsPlaceholderImage(width: 300, height: 400);
+
+            var johnDoe = A.New<Profile>();
+
+            //assert
+            string expected = @"http://placehold.it/300x400";
+            Assert.True(johnDoe.AvatarUrl == expected);
+        }
+
+        [Fact]
+        public void ShouldCreateImgTagUsingWidthAndHeightText()
+        {
+            A.Configure<Profile>()
+                .Fill(p => p.AvatarUrl)
+                .AsPlaceholderImage(width: 300, height: 400, text: "Sample");
+
+            var johnDoe = A.New<Profile>();
+
+            //assert
+            string expected = @"http://placehold.it/300x400?text=Sample";
+            Assert.True(johnDoe.AvatarUrl == expected);
+        }
+
+        [Fact]
+        public void ShouldCreateImgTagUsingWidthAndHeightPngFormat()
+        {
+            A.Configure<Profile>()
+                .Fill(p => p.AvatarUrl)
+                .AsPlaceholderImage(width: 300, height: 400, format: ImgFormat.PNG);
+
+            var johnDoe = A.New<Profile>();
+
+            //assert
+            string expected = @"http://placehold.it/300x400.PNG";
+            Assert.True(johnDoe.AvatarUrl == expected);
+        }
+
+        [Fact]
+        public void ShouldCreateImgTagUsingWidthAndHeightColor()
+        {
+            A.Configure<Profile>()
+                          .Fill(p => p.AvatarUrl)
+                          .AsPlaceholderImage(width: 300, height: 400, textColor: "FFFFFF", backgroundColor: "000000");
+
+            var johnDoe = A.New<Profile>();
+
+            //assert
+            string expected = @"http://placehold.it/300x400/000000/FFFFFF";
+            Assert.True(johnDoe.AvatarUrl == expected);
+        }
+
+        [Fact]
+        public void ShouldCreateImgTagUsingWidthAndHeightColorText()
+        {
+            A.Configure<Profile>()
+                          .Fill(p => p.AvatarUrl)
+                          .AsPlaceholderImage(width: 300, height: 400, textColor: "FFFFFF", backgroundColor: "000000", text: "Sample");
+
+            var johnDoe = A.New<Profile>();
+
+            //assert
+            string expected = @"http://placehold.it/300x400/000000/FFFFFF?text=Sample";
+            Assert.True(johnDoe.AvatarUrl == expected);
+        }
+
+        [Fact]
+        public void ShouldCreateImgTagUsingWidthAndHeightColorTextFormat()
+        {
+            A.Configure<Profile>()
+                          .Fill(p => p.AvatarUrl)
+                          .AsPlaceholderImage(width: 300, height: 400, textColor: "FFFFFF", backgroundColor: "000000", text: "Sample", format: ImgFormat.PNG);
+
+            var johnDoe = A.New<Profile>();
+
+            //assert
+            string expected = @"http://placehold.it/300x400.PNG/000000/FFFFFF?text=Sample";
+            Assert.True(johnDoe.AvatarUrl == expected);
+
+        }
+
+    }
+}


### PR DESCRIPTION
Adds the `AsPlaceholderImage` extension method which allows a property to be filled with a placeholder image URL. This url points to the placehold.it web service. Developers can specify, width, height, background/text colors, text, and image formats.

   ```
 A.Configure<Person>().Fill(p => p.AvatarUrl).AsPlaceholderImage(
        width: 300, 
        height: 400,,
        text:"Sample",
        backgroundColor:"555555",
        textColor: "FFFFFF",
        format: ImgFormat.PNG
        );
// => "http://placehold.it/300x400.PNG/000000/FFFFFF?text=Sample"
```