### PR TITLE
Adding support for filling enums

### DIFF
--- a/src/GenFu/DefaultValueChecker.cs
+++ b/src/GenFu/DefaultValueChecker.cs
@@ -43,6 +43,8 @@ namespace GenFu
                 return false;
             else if (property.PropertyType == typeof(DateTimeOffset) && ((DateTimeOffset)value).Equals(default(DateTimeOffset)))
                 return false;
+            else if (property.PropertyType.GetTypeInfo().BaseType == typeof(System.Enum) && ((int)value) == 0)
+                return false;
             return true;
         }
     }

--- a/src/GenFu/FillerManager.cs
+++ b/src/GenFu/FillerManager.cs
@@ -153,6 +153,10 @@ namespace GenFu
                 {
                     result = _genericPropertyFillersByPropertyType[propertyInfo.PropertyType];
                 }
+                else if(propertyInfo.PropertyType.GetTypeInfo().BaseType == typeof(System.Enum))
+                {
+                    result = new EnumFiller(propertyInfo.PropertyType);
+                }
                 else
                 {
                     //TODO: Can we build a custom filler here for other value types that we have not explicitly implemented (eg. long, decimal, etc.)

--- a/src/GenFu/Fillers/EnumFiller.cs
+++ b/src/GenFu/Fillers/EnumFiller.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Linq;
+
+namespace GenFu
+{
+    public class EnumFiller : PropertyFiller<Enum>
+    {
+        readonly Type _type;
+        public EnumFiller(Type type)
+            : base(new[] { "object" }, new[] { "*" }, true)
+        {
+            this._type = type;
+        }
+
+        public override object GetValue(object instance)
+        {
+            var values = Enum.GetValues(_type);
+            return values.GetValue(new Random().Next(values.Length-1));
+        }
+    }
+}

--- a/src/GenFu/Fillers/StringFillers.cs
+++ b/src/GenFu/Fillers/StringFillers.cs
@@ -17,7 +17,6 @@ namespace GenFu
             return BaseValueGenerator.Word();
         }
     }
-
     public class ArticleTitleFiller : PropertyFiller<string>
     {
         public ArticleTitleFiller()

--- a/tests/GenFu.Tests/ExtensionMethodTests.cs
+++ b/tests/GenFu.Tests/ExtensionMethodTests.cs
@@ -1,6 +1,7 @@
 ﻿using GenFu;
 using Xunit;
 using System.Linq;
+using GenFu.Tests.TestEntities;
 
 namespace GenFu.Tests
 {

--- a/tests/GenFu.Tests/Fillers/BasicFillTests.cs
+++ b/tests/GenFu.Tests/Fillers/BasicFillTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GenFu.ValueGenerators.Geospatial;
 using GenFu.ValueGenerators.Medical;
 using GenFu.ValueGenerators.People;
+using GenFu.Tests.TestEntities;
 
 namespace GenFu.Tests
 {

--- a/tests/GenFu.Tests/Fillers/EnumFillerTests.cs
+++ b/tests/GenFu.Tests/Fillers/EnumFillerTests.cs
@@ -1,0 +1,17 @@
+﻿using GenFu.Tests.TestEntities;
+using System;
+using Xunit;
+
+namespace GenFu.Tests.Fillers
+{
+    public class EnumFillerTests
+    {
+        [Fact]
+        void Can_get_a_value()
+        {
+            var sut = new EnumFiller(typeof(BlogTypeEnum));
+            var result = (BlogTypeEnum)sut.GetValue(null);
+            Assert.NotNull(Enum.GetName(typeof(BlogTypeEnum), result));
+        }
+    }
+}

--- a/tests/GenFu.Tests/GenFu.Tests.csproj
+++ b/tests/GenFu.Tests/GenFu.Tests.csproj
@@ -17,6 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="TestData\singlename.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -28,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
   </ItemGroup>
 

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -297,6 +297,13 @@ namespace GenFu.Tests
         }
 
         [Fact]
+        public void An_enum_should_be_filled()
+        {
+            var post = A.New<BlogPost>();
+            Assert.True((int)post.Type > 0);
+        }
+
+        [Fact]
         public void DateTimesStayWithinConfiguredDates()
         {
             var success = true;

--- a/tests/GenFu.Tests/TestEntities/BlogPost.cs
+++ b/tests/GenFu.Tests/TestEntities/BlogPost.cs
@@ -3,13 +3,14 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace GenFu.Tests
+namespace GenFu.Tests.TestEntities
 {
     internal class BlogPost
     {
         public int BlogPostId { get; set; }
         public string Title { get; set; }
         public string Body { get; set; }
+        public BlogTypeEnum Type { get; set; }
         public virtual ICollection<BlogComment> Comments { get; set; }
         public DateTime CreateDate { get; set; }
     }

--- a/tests/GenFu.Tests/TestEntities/BlogTypeEnum.cs
+++ b/tests/GenFu.Tests/TestEntities/BlogTypeEnum.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GenFu.Tests.TestEntities
+{
+    enum BlogTypeEnum
+    {
+        Post = 1,
+        Update = 2,
+        ProductRelease = 3
+    }
+}

--- a/tests/GenFu.Tests/When_configuring_property_with_custom_filler.cs
+++ b/tests/GenFu.Tests/When_configuring_property_with_custom_filler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GenFu.Tests.TestEntities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/GenFu.Tests/When_configuring_property_with_specific_value.cs
+++ b/tests/GenFu.Tests/When_configuring_property_with_specific_value.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GenFu.Tests.TestEntities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/GenFu.Tests/When_filling_object_graph.cs
+++ b/tests/GenFu.Tests/When_filling_object_graph.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using GenFu;
 using Xunit;
+using GenFu.Tests.TestEntities;
 
 namespace GenFu.Tests
 {

--- a/tests/GenFu.Tests/When_testing_for_default_values.cs
+++ b/tests/GenFu.Tests/When_testing_for_default_values.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GenFu.Tests.TestEntities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -106,6 +107,20 @@ namespace GenFu.Tests
         {
             var post = new BlogPost { CreateDate = DateTime.Now };
             Assert.True(DefaultValueChecker.HasValue(post, typeof(BlogPost).GetProperties().First(x => x.Name == "CreateDate")));
+        }
+
+        [Fact]
+        public void Filled_enum_should_return_true()
+        {
+            var post = new BlogPost { Type = BlogTypeEnum.Post};
+            Assert.True(DefaultValueChecker.HasValue(post, typeof(BlogPost).GetProperties().First(x => x.Name == "Type")));
+        }
+
+        [Fact]
+        public void Empty_enum_should_return_false()
+        {
+            var post = new BlogPost();
+            Assert.False(DefaultValueChecker.HasValue(post, typeof(BlogPost).GetProperties().First(x => x.Name == "Type")));
         }
     }
 }


### PR DESCRIPTION
Previously enums were not filled by GenFu. With this update, enums will be assigned a random value from their possible values.  No changes should be needed to just start filling values. 

I don't think this will be a breaking change so I don't think we need more than a minor version number bump. 