### PR TITLE
Fix new race condition

### DIFF
--- a/src/GenFu/FillerManager.cs
+++ b/src/GenFu/FillerManager.cs
@@ -328,12 +328,27 @@ namespace GenFu
         public Result GetGenericFiller<Input, Result>()
         {
             var type = typeof(Input);
-            return (Result)_genericPropertyFillersByPropertyType[type];
+            try
+            {
+                rwl.EnterReadLock();
+                return (Result) _genericPropertyFillersByPropertyType[type];
+            }
+            finally
+            {
+                rwl.ExitReadLock();
+            }
         }
         public IPropertyFiller GetGenericFillerForType(Type t)
         {
-            return _genericPropertyFillersByPropertyType[t];
+            try
+            {
+                rwl.EnterReadLock();
+                return _genericPropertyFillersByPropertyType[t];
+            }
+            finally
+            {
+                rwl.ExitReadLock();
+            }
         }
-
     }
 }

--- a/tests/GenFu.Tests/When_running_in_parallel.cs
+++ b/tests/GenFu.Tests/When_running_in_parallel.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using GenFu.Tests.TestEntities;
 using Xunit;
 
@@ -58,48 +59,6 @@ namespace GenFu.Tests
 
                 Assert.True(person.Age >= 40 && person.Age <= 50);
             });
-        }
-
-
-
-        [Fact]
-        public void registration_changes_are_non_deterministic()
-        {
-            /*
-             * this is not exactly a test
-             * we demosntrate here that, while the FillerManager is thread safe, 
-             * it is not deterministic for multithreading
-             * because we have only one shared storage
-             */
-            /*
-             * THIS TEST CAN BE SAFELY DELETED 
-             */
-
-            var testOneGreaterThan100 = false;
-            var testOneSmallerThan100 = false;
-            var testTwoGreaterThan100 = false;
-            var testTwoSmallerThan100 = false;
-
-            Parallel.For(0, 1000, i =>
-            {
-                //conf #1
-                A.Configure<Person>().Fill(x => x.Id).WithinRange(200, 300);
-
-                var one = A.New<Person>();
-                testOneGreaterThan100 = testOneGreaterThan100 || one.Id > 100; //comes from conf#1 in any thread
-                testOneSmallerThan100 = testOneSmallerThan100 || one.Id < 100; //comes from conf#2 in another thread
-
-                //conf #2
-                A.Configure<Person>().Fill(x => x.Id).WithinRange(20, 30);
-
-                var two = A.New<Person>();
-                testTwoGreaterThan100 = testTwoGreaterThan100 || two.Id > 100; //comes from conf#1 in any thread
-                testTwoSmallerThan100 = testTwoSmallerThan100 || two.Id < 100; //comes from conf#2 in another thread
-            });
-
-            //if it were ran in a single thread both assertions would fail
-            Assert.True(testOneGreaterThan100 && testOneSmallerThan100); //result is not deterministic 
-            Assert.True(testTwoGreaterThan100 && testTwoSmallerThan100); //result is not deterministic 
         }
     }
 }


### PR DESCRIPTION
This code fixes a new race condition in Filler manager that appeared since #133 was created, regarding generic fillers.

Note that parallel tests and all the other tests should not be executed together. Parallel tests reset registrations interfering other tests.