### PR TITLE
Genfu instances

### DIFF
--- a/src/GenFu/FillerManager.cs
+++ b/src/GenFu/FillerManager.cs
@@ -328,12 +328,27 @@ namespace GenFu
         public Result GetGenericFiller<Input, Result>()
         {
             var type = typeof(Input);
-            return (Result)_genericPropertyFillersByPropertyType[type];
+            try
+            {
+                rwl.EnterReadLock();
+                return (Result) _genericPropertyFillersByPropertyType[type];
+            }
+            finally
+            {
+                rwl.ExitReadLock();
+            }
         }
         public IPropertyFiller GetGenericFillerForType(Type t)
         {
-            return _genericPropertyFillersByPropertyType[t];
+            try
+            {
+                rwl.EnterReadLock();
+                return _genericPropertyFillersByPropertyType[t];
+            }
+            finally
+            {
+                rwl.ExitReadLock();
+            }
         }
-
     }
 }

--- a/src/GenFu/FillerManager.cs
+++ b/src/GenFu/FillerManager.cs
@@ -14,11 +14,18 @@ namespace GenFu
         private IDictionary<Type, IPropertyFiller> _genericPropertyFillersByPropertyType;
         private IList<IPropertyFiller> _propertyFillers;
 
-        static ReaderWriterLockSlim rwl = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
-
+        private ReaderWriterLockSlim rwl = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+        public GenFuInstance GenFu { get; }
 
         public FillerManager()
         {
+            GenFu = A.GenFuInstance;
+            ResetFillers();
+        }
+
+        public FillerManager(GenFuInstance genFu)
+        {
+            GenFu = genFu;
             ResetFillers();
         }
 
@@ -31,68 +38,68 @@ namespace GenFu
                 {
                     _propertyFillers = new List<IPropertyFiller>();
 
-                    _propertyFillers.Add(new CharFiller());
-                    _propertyFillers.Add(new NullableCharFiller());
-                    _propertyFillers.Add(new IntFiller());
-                    _propertyFillers.Add(new NullableIntFiller());
-                    _propertyFillers.Add(new NullableUIntFiller());
-                    _propertyFillers.Add(new LongFiller());
-                    _propertyFillers.Add(new NullableLongFiller());
-                    _propertyFillers.Add(new NullableULongFiller());
-                    _propertyFillers.Add(new DecimalFiller());
-                    _propertyFillers.Add(new NullableDecimalFiller());
-                    _propertyFillers.Add(new ShortFiller());
-                    _propertyFillers.Add(new NullableShortFiller());
-                    _propertyFillers.Add(new NullableUShortFiller());
-                    _propertyFillers.Add(new BooleanFiller());
-                    _propertyFillers.Add(new NullableBooleanFiller());
+                    _propertyFillers.Add(new CharFiller(GenFu));
+                    _propertyFillers.Add(new NullableCharFiller(GenFu));
+                    _propertyFillers.Add(new IntFiller(GenFu));
+                    _propertyFillers.Add(new NullableIntFiller(GenFu));
+                    _propertyFillers.Add(new NullableUIntFiller(GenFu));
+                    _propertyFillers.Add(new LongFiller(GenFu));
+                    _propertyFillers.Add(new NullableLongFiller(GenFu));
+                    _propertyFillers.Add(new NullableULongFiller(GenFu));
+                    _propertyFillers.Add(new DecimalFiller(GenFu));
+                    _propertyFillers.Add(new NullableDecimalFiller(GenFu));
+                    _propertyFillers.Add(new ShortFiller(GenFu));
+                    _propertyFillers.Add(new NullableShortFiller(GenFu));
+                    _propertyFillers.Add(new NullableUShortFiller(GenFu));
+                    _propertyFillers.Add(new BooleanFiller(GenFu));
+                    _propertyFillers.Add(new NullableBooleanFiller(GenFu));
 
-                    _propertyFillers.Add(new AgeFiller());
-                    _propertyFillers.Add(new PriceFiller());
+                    _propertyFillers.Add(new AgeFiller(GenFu));
+                    _propertyFillers.Add(new PriceFiller(GenFu));
 
-                    _propertyFillers.Add(new CompanyNameFiller());
+                    _propertyFillers.Add(new CompanyNameFiller(GenFu));
 
-                    _propertyFillers.Add(new CookingFiller.IngredientFiller());
+                    _propertyFillers.Add(new CookingFiller.IngredientFiller(GenFu));
 
 
-                    DateTimeNullableFiller DateTimeNullableFiller = new DateTimeAdapterFiller<DateTime?>();
-                    _propertyFillers.Add(new DateTimeFiller());
-                    _propertyFillers.Add(new DateTimeOffsetFiller());
+                    DateTimeNullableFiller DateTimeNullableFiller = new DateTimeAdapterFiller<DateTime?>(GenFu);
+                    _propertyFillers.Add(new DateTimeFiller(GenFu));
+                    _propertyFillers.Add(new DateTimeOffsetFiller(GenFu));
                     _propertyFillers.Add(DateTimeNullableFiller);
 
 
-                    _propertyFillers.Add(new BirthDateFiller());
-                    _propertyFillers.Add(new GuidFiller());
-                    _propertyFillers.Add(new ArticleTitleFiller());
+                    _propertyFillers.Add(new BirthDateFiller(GenFu));
+                    _propertyFillers.Add(new GuidFiller(GenFu));
+                    _propertyFillers.Add(new ArticleTitleFiller(GenFu));
 
-                    _propertyFillers.Add(new FirstNameFiller());
-                    _propertyFillers.Add(new LastNameFiller());
-                    _propertyFillers.Add(new EmailFiller());
-                    _propertyFillers.Add(new PersonTitleFiller());
+                    _propertyFillers.Add(new FirstNameFiller(GenFu));
+                    _propertyFillers.Add(new LastNameFiller(GenFu));
+                    _propertyFillers.Add(new EmailFiller(GenFu));
+                    _propertyFillers.Add(new PersonTitleFiller(GenFu));
 
-                    _propertyFillers.Add(new TwitterFiller());
+                    _propertyFillers.Add(new TwitterFiller(GenFu));
 
-                    _propertyFillers.Add(new AddressFiller());
-                    _propertyFillers.Add(new AddressLine2Filler());
-                    _propertyFillers.Add(new CityFiller());
-                    _propertyFillers.Add(new StateFiller());
-                    _propertyFillers.Add(new ProvinceFiller());
-                    _propertyFillers.Add(new ZipCodeFiller());
-                    _propertyFillers.Add(new PostalCodeFiller());
-                    _propertyFillers.Add(new PhoneNumberFiller());
+                    _propertyFillers.Add(new AddressFiller(GenFu));
+                    _propertyFillers.Add(new AddressLine2Filler(GenFu));
+                    _propertyFillers.Add(new CityFiller(GenFu));
+                    _propertyFillers.Add(new StateFiller(GenFu));
+                    _propertyFillers.Add(new ProvinceFiller(GenFu));
+                    _propertyFillers.Add(new ZipCodeFiller(GenFu));
+                    _propertyFillers.Add(new PostalCodeFiller(GenFu));
+                    _propertyFillers.Add(new PhoneNumberFiller(GenFu));
 
-                    _propertyFillers.Add(new MusicAlbumTitleFiller());
-                    _propertyFillers.Add(new MusicArtistNameFiller());
-                    _propertyFillers.Add(new MusicGenreDescriptionFiller());
-                    _propertyFillers.Add(new MusicGenreNameFiller());
+                    _propertyFillers.Add(new MusicAlbumTitleFiller(GenFu));
+                    _propertyFillers.Add(new MusicArtistNameFiller(GenFu));
+                    _propertyFillers.Add(new MusicGenreDescriptionFiller(GenFu));
+                    _propertyFillers.Add(new MusicGenreNameFiller(GenFu));
 
-                    _propertyFillers.Add(new CanadianSocialInsuranceNumberFiller());
-                    _propertyFillers.Add(new USASocialSecurityNumberFiller());
+                    _propertyFillers.Add(new CanadianSocialInsuranceNumberFiller(GenFu));
+                    _propertyFillers.Add(new USASocialSecurityNumberFiller(GenFu));
 
-                    _propertyFillers.Add(new DrugFiller());
-                    _propertyFillers.Add(new MedicalProcedureFiller());
+                    _propertyFillers.Add(new DrugFiller(GenFu));
+                    _propertyFillers.Add(new MedicalProcedureFiller(GenFu));
 
-                    _propertyFillers.Add(new StringFiller());
+                    _propertyFillers.Add(new StringFiller(GenFu));
 
                 }
 
@@ -199,12 +206,12 @@ namespace GenFu
                     }
                     else if (propertyInfo.PropertyType.GetTypeInfo().BaseType == typeof(System.Enum))
                     {
-                        result = new EnumFiller(propertyInfo.PropertyType);
+                        result = new EnumFiller(this.GenFu, propertyInfo.PropertyType);
                     }
                     else
                     {
                         //TODO: Can we build a custom filler here for other value types that we have not explicitly implemented (eg. long, decimal, etc.)
-                        result = new CustomFiller<object>("*", typeof(object), true, () => null);
+                        result = new CustomFiller<object>(GenFu, "*", typeof(object), true, () => null);
                         newRegistrations[propertyInfo.PropertyType] = result;
                     }
                 }

--- a/src/GenFu/Fillers/BooleanFiller.cs
+++ b/src/GenFu/Fillers/BooleanFiller.cs
@@ -6,13 +6,16 @@ namespace GenFu.Fillers
 {
     public class BooleanFiller : PropertyFiller<bool>
     {
+        public BooleanFiller() : this(A.GenFuInstance) { }
 
-        public BooleanFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public BooleanFiller(Type objectType, string propertyName) : this(A.GenFuInstance, objectType, propertyName) { }
+
+        public BooleanFiller(GenFuInstance genfu) : base(genfu, new[] { "object" }, new[] { "*" }, true)
         {
 
         }
 
-        public BooleanFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public BooleanFiller(GenFuInstance genfu, Type objectType, string propertyName) : base(genfu, new[] { objectType.FullName }, new[] { propertyName })
         {
 
         }
@@ -25,13 +28,14 @@ namespace GenFu.Fillers
 
     public class NullableBooleanFiller : PropertyFiller<bool?>
     {
+        public NullableBooleanFiller() : this(A.GenFuInstance) { }
 
-        public NullableBooleanFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableBooleanFiller(GenFuInstance genfu) : base(genfu, new[] { "object" }, new[] { "*" }, true)
         {
 
         }
 
-        public NullableBooleanFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableBooleanFiller(GenFuInstance genfu,Type objectType, string propertyName) : base(genfu, new[] { objectType.FullName }, new[] { propertyName })
         {
 
         }

--- a/src/GenFu/Fillers/CanadianSocialInsuranceNumberFiller.cs
+++ b/src/GenFu/Fillers/CanadianSocialInsuranceNumberFiller.cs
@@ -9,7 +9,11 @@ namespace GenFu.Fillers
     class CanadianSocialInsuranceNumberFiller : PropertyFiller<String>
     {
         public CanadianSocialInsuranceNumberFiller()
-            : base(new[] { "object" }, new[] { "SIN", "SocialInsuranceNumber" })
+            : base(A.GenFuInstance, new[] { "object" }, new[] { "SIN", "SocialInsuranceNumber" })
+        { }
+
+        public CanadianSocialInsuranceNumberFiller(GenFuInstance genfu)
+            : base(genfu, new[] { "object" }, new[] { "SIN", "SocialInsuranceNumber" })
         { }
 
         public override object GetValue(object instance)

--- a/src/GenFu/Fillers/CharFiller.cs
+++ b/src/GenFu/Fillers/CharFiller.cs
@@ -6,32 +6,36 @@ namespace GenFu.Fillers
 {
     public class CharFiller : PropertyFiller<char>
     {
+        public CharFiller() : this(A.GenFuInstance) { }
 
-        public CharFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public CharFiller(Type objectType, string propertyName) : this(A.GenFuInstance, objectType, propertyName) { }
+
+        public CharFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
 
         }
 
-        public CharFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public CharFiller(GenFuInstance genFu, Type objectType, string propertyName) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
 
         }
 
         public override object GetValue(object instance)
         {
-            return (char)GenFu.Random.Next(char.MinValue, char.MaxValue);
+            return (char)this.GenFu.Random.Next(char.MinValue, char.MaxValue);
         }
     }
 
     public class NullableCharFiller : PropertyFiller<char?>
     {
+        public NullableCharFiller() : this(A.GenFuInstance) { }
 
-        public NullableCharFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableCharFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
 
         }
 
-        public NullableCharFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableCharFiller(GenFuInstance genFu, Type objectType, string propertyName) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
 
         }

--- a/src/GenFu/Fillers/CompanyNameFiller.cs
+++ b/src/GenFu/Fillers/CompanyNameFiller.cs
@@ -7,7 +7,9 @@ namespace GenFu.Fillers
 {
     class CompanyNameFiller : PropertyFiller<string>, IPropertyFiller
     {
-        public CompanyNameFiller(): base (new[] { "company" }, new[] { "name" }, false)
+        public CompanyNameFiller() : this(A.GenFuInstance) { }
+
+        public CompanyNameFiller(GenFuInstance genFu) : base (genFu, new[] { "company" }, new[] { "name" }, false)
         {}
 
         public override object GetValue(object instance)

--- a/src/GenFu/Fillers/CookingFiller.cs
+++ b/src/GenFu/Fillers/CookingFiller.cs
@@ -9,8 +9,10 @@ namespace GenFu.Fillers
     {
         public class IngredientFiller : PropertyFiller<string>
         {
-            public IngredientFiller()
-                : base(new[] { "object" }, new[] { "ingredient", "ingredients" })
+            public IngredientFiller() : this(A.GenFuInstance) { }
+
+            public IngredientFiller(GenFuInstance genFu)
+                : base(genFu, new[] { "object" }, new[] { "ingredient", "ingredients" })
             {
             }
 
@@ -19,6 +21,6 @@ namespace GenFu.Fillers
                 return ValueGenerators.Cooking.Ingredients.Ingredient();
             }
         }
-     
+
     }
 }

--- a/src/GenFu/Fillers/CustomFillers.cs
+++ b/src/GenFu/Fillers/CustomFillers.cs
@@ -9,13 +9,15 @@ namespace GenFu
     {
         private Func<T> _filler;
 
-        public CustomFiller(string propertyName, Type objectType, Func<T> filler)
-            : this(propertyName, objectType, false, filler)
+        public CustomFiller(string propertyName, Type objectType, Func<T> filler) : this(A.GenFuInstance, propertyName, objectType, filler) { }
+
+        public CustomFiller(GenFuInstance genfu, string propertyName, Type objectType, Func<T> filler)
+            : this(genfu, propertyName, objectType, false, filler)
         {
         }
 
-        internal CustomFiller(string propertyName, Type objectType, bool isGeneric, Func<T> filler)
-            : base(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
+        internal CustomFiller(GenFuInstance genfu, string propertyName, Type objectType, bool isGeneric, Func<T> filler)
+            : base(genfu, new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
         {
             if (objectType != typeof(Object))
                 AddAllBaseTypes(propertyName, objectType);
@@ -46,12 +48,17 @@ namespace GenFu
         private Func<T1, T2> _filler;
 
         public CustomFiller(string propertyName, Type objectType, Func<T1, T2> filler)
-            : this(propertyName, objectType, false, filler)
+            : this(A.GenFuInstance, propertyName, objectType, false, filler)
         {
         }
 
-        internal CustomFiller(string propertyName, Type objectType, bool isGeneric, Func<T1, T2> filler)
-            : base(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
+        public CustomFiller(GenFuInstance genfu, string propertyName, Type objectType, Func<T1, T2> filler)
+            : this(genfu, propertyName, objectType, false, filler)
+        {
+        }
+
+        internal CustomFiller(GenFuInstance genfu, string propertyName, Type objectType, bool isGeneric, Func<T1, T2> filler)
+            : base(genfu, new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
         {
             _filler = filler;
         }

--- a/src/GenFu/Fillers/DateTimeAdapterFiller.cs
+++ b/src/GenFu/Fillers/DateTimeAdapterFiller.cs
@@ -5,7 +5,20 @@ namespace GenFu.Fillers
 {
     public class DateTimeAdapterFiller<T> : DateTimeNullableFiller
     {
-        DateTimeFiller dateTimeFiller = new DateTimeFiller();
+        public DateTimeAdapterFiller(GenFuInstance genFu) : base(genFu)
+        {
+
+        }
+
+        DateTimeFiller _dateTimeFiller = null;
+        DateTimeFiller DateTimeFiller
+        {
+            get
+            {
+                _dateTimeFiller = _dateTimeFiller ?? new DateTimeFiller(this.GenFu);
+                return _dateTimeFiller;
+            }
+        }
         private Random rand = new Random();
 
         public override object GetValue(object instance)
@@ -18,11 +31,11 @@ namespace GenFu.Fillers
                 }
                 else
                 {
-                    return dateTimeFiller.GetValue(instance);
+                    return DateTimeFiller.GetValue(instance);
                 }
             }
 
-            return dateTimeFiller.GetValue(instance);
+            return DateTimeFiller.GetValue(instance);
         }
     }
 }

--- a/src/GenFu/Fillers/DateTimeFillers.cs
+++ b/src/GenFu/Fillers/DateTimeFillers.cs
@@ -10,8 +10,10 @@ namespace GenFu
         public DateTime Min { get; set; } = new DateTime(1900, 01, 01);
         public DateTime Max { get; set; } = new DateTime(2020, 12, 31);
 
-        public DateTimeFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public DateTimeFiller() : this(A.GenFuInstance) { }
+
+        public DateTimeFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
 
         }
@@ -35,29 +37,33 @@ namespace GenFu
     {
         private Random _random = new Random();
 
-        public DateTimeOffsetFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public DateTimeOffsetFiller() : this(A.GenFuInstance) { }
+
+        public DateTimeOffsetFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
 
         }
 
         public override object GetValue(object instance)
         {
-            
-            return new DateTimeOffset(new DateTimeFiller().GetRandomDate());
+
+            return new DateTimeOffset(new DateTimeFiller(GenFu).GetRandomDate());
         }
     }
 
     public class BirthDateFiller : PropertyFiller<DateTime>
     {
-        public BirthDateFiller()
-            : base(new[] { "object" }, new[] { "birthdate", "birth_date" })
+        public BirthDateFiller() : this(A.GenFuInstance) { }
+
+        public BirthDateFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "birthdate", "birth_date" })
         {
         }
 
         public override object GetValue(object instance)
         {
-            return CalendarDate.Date(DateTime.Today.AddYears(-110), DateTime.Today);
+            return new CalendarDate(GenFu).Date(DateTime.Today.AddYears(-110), DateTime.Today);
         }
     }
 
@@ -72,8 +78,8 @@ namespace GenFu
         public static GenFuConfigurator<T> AsPastDate<T>(this GenFuDateTimeConfigurator<T> configurator)
             where T : new()
         {
-            CustomFiller<DateTime> filler = new CustomFiller<DateTime>(configurator.PropertyInfo.Name, typeof(T),
-                                                                   () => CalendarDate.Date(DateRules.PastDate));
+            CustomFiller<DateTime> filler = new CustomFiller<DateTime>(configurator.GenFu, configurator.PropertyInfo.Name, typeof(T),
+                                                                   () => new CalendarDate(configurator.GenFu).Date(DateRules.PastDate));
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -87,8 +93,8 @@ namespace GenFu
         public static GenFuConfigurator<T> AsFutureDate<T>(this GenFuDateTimeConfigurator<T> configurator)
             where T : new()
         {
-            CustomFiller<DateTime> filler = new CustomFiller<DateTime>(configurator.PropertyInfo.Name, typeof(T),
-                                                                   () => CalendarDate.Date(DateRules.FutureDates));
+            CustomFiller<DateTime> filler = new CustomFiller<DateTime>(configurator.GenFu, configurator.PropertyInfo.Name, typeof(T),
+                                                                   () => new CalendarDate(configurator.GenFu).Date(DateRules.FutureDates));
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }

--- a/src/GenFu/Fillers/DateTimeNullableFillers.cs
+++ b/src/GenFu/Fillers/DateTimeNullableFillers.cs
@@ -10,8 +10,10 @@ namespace GenFu
         public DateTime Max { get; set; }
         public double SeedPercentage { get; set; } = 1;
 
-        public DateTimeNullableFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public DateTimeNullableFiller() : this(A.GenFuInstance) { }
+
+        public DateTimeNullableFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
         }
 

--- a/src/GenFu/Fillers/DrugFiller.cs
+++ b/src/GenFu/Fillers/DrugFiller.cs
@@ -6,8 +6,10 @@ namespace GenFu.Fillers
 { 
     public class DrugFiller : PropertyFiller<string>
     {
-        public DrugFiller()
-            : base(new[] { "object" }, new[] { "drug", "drugs", "Rx", "perscription" })
+        public DrugFiller() : this(A.GenFuInstance) { }
+
+        public DrugFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "drug", "drugs", "Rx", "perscription" })
         {
         }
 

--- a/src/GenFu/Fillers/EnumFiller.cs
+++ b/src/GenFu/Fillers/EnumFiller.cs
@@ -6,8 +6,14 @@ namespace GenFu
     public class EnumFiller : PropertyFiller<Enum>
     {
         readonly Type _type;
+
         public EnumFiller(Type type)
-            : base(new[] { "object" }, new[] { "*" }, true)
+            : this(A.GenFuInstance, type)
+        {
+        }
+
+        public EnumFiller(GenFuInstance genFu, Type type)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             this._type = type;
         }

--- a/src/GenFu/Fillers/GuidFiller.cs
+++ b/src/GenFu/Fillers/GuidFiller.cs
@@ -4,8 +4,10 @@ namespace GenFu.Fillers
 {
     class GuidFiller:PropertyFiller<Guid>
     {
-        public GuidFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public GuidFiller() : this(A.GenFuInstance) { }
+
+        public GuidFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         { }
 
         public override object GetValue(object instance)

--- a/src/GenFu/Fillers/InjuryFiller.cs
+++ b/src/GenFu/Fillers/InjuryFiller.cs
@@ -6,8 +6,10 @@ namespace GenFu.Fillers
 {
     public class InjuryFiller : PropertyFiller<string>
     {
-        public InjuryFiller()
-            : base(new[] { "object" }, new[] { "injury" })
+        public InjuryFiller() : this(A.GenFuInstance) { }
+
+        public InjuryFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "injury" })
         {
         }
 

--- a/src/GenFu/Fillers/MedicalProcedureFiller.cs
+++ b/src/GenFu/Fillers/MedicalProcedureFiller.cs
@@ -6,8 +6,10 @@ namespace GenFu.Fillers
 {
     public class MedicalProcedureFiller : PropertyFiller<string>
     {
-        public MedicalProcedureFiller()
-            : base(new[] { "object" }, new[] { "procedure", "MedicalProcedure" })
+        public MedicalProcedureFiller() : this(A.GenFuInstance) { }
+
+        public MedicalProcedureFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "procedure", "MedicalProcedure" })
         {
         }
 

--- a/src/GenFu/Fillers/NumericFillers.cs
+++ b/src/GenFu/Fillers/NumericFillers.cs
@@ -1,17 +1,22 @@
 ﻿using System;
 
+using GenfuStatic = GenFu.GenFu;
+
 namespace GenFu
 {
     public class IntFiller : PropertyFiller<int>
     {
+        public IntFiller() : this(A.GenFuInstance) { }
 
-        public IntFiller() : base(new []{"object"}, new []{"*"}, true)
+        public IntFiller(Type objectType, string propertyName, int min, int max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public IntFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
-            Min = GenFu.Defaults.MIN_INT;
-            Max = GenFu.Defaults.MAX_INT;
+            Min = genFu.Defaults.MIN_INT;
+            Max = genFu.Defaults.MAX_INT;
         }
 
-        public IntFiller(Type objectType, string propertyName, int min, int max) : base(new []{objectType.FullName}, new []{propertyName})
+        public IntFiller(GenFuInstance genFu, Type objectType, string propertyName, int min, int max) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -22,20 +27,22 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return GenFu.Random.Next(Min, Max);
+            return this.GenFu.Random.Next(Min, Max);
         }
     }
 
     public class NullableIntFiller : PropertyFiller<int?>
     {
+        public NullableIntFiller() : this(A.GenFuInstance) { }
+        public NullableIntFiller(Type objectType, string propertyName, int min, int max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
 
-        public NullableIntFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableIntFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
-            Min = GenFu.Defaults.MIN_INT;
+            Min = this.GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public NullableIntFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableIntFiller(GenFuInstance genFu, Type objectType, string propertyName, int min, int max) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -46,20 +53,23 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return new int?(GenFu.Random.Next(Min, Max));
+            return new int?(this.GenFu.Random.Next(Min, Max));
         }
     }
 
     public class NullableUIntFiller : PropertyFiller<uint?>
     {
+        public NullableUIntFiller(): this(A.GenFuInstance) { }
 
-        public NullableUIntFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableUIntFiller(Type objectType, string propertyName, uint min, uint max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableUIntFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_UINT;
             Max = GenFu.Defaults.MAX_UINT;
         }
 
-        public NullableUIntFiller(Type objectType, string propertyName, uint min, uint max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableUIntFiller(GenFuInstance genFu, Type objectType, string propertyName, uint min, uint max) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -70,21 +80,24 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return new uint?((uint)GenFu.Random.Next((int)Min, (int)Max));
+            return new uint?((uint)this.GenFu.Random.Next((int)Min, (int)Max));
         }
     }
 
     public class ShortFiller : PropertyFiller<short>
     {
+        public ShortFiller() : this(A.GenFuInstance) { }
 
-        public ShortFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public ShortFiller(Type objectType, string propertyName, short min, short max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public ShortFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_SHORT;
             Max = GenFu.Defaults.MAX_SHORT;
         }
 
-        public ShortFiller(Type objectType, string propertyName, short min, short max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public ShortFiller(GenFuInstance genFu, Type objectType, string propertyName, short min, short max)
+            : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -96,21 +109,24 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return (short) GenFu.Random.Next(Min, Max);
+            return (short)this.GenFu.Random.Next(Min, Max);
         }
     }
 
     public class NullableShortFiller : PropertyFiller<short?>
     {
+        public NullableShortFiller() : this(A.GenFuInstance) { }
 
-        public NullableShortFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableShortFiller(Type objectType, string propertyName, short min, short max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableShortFiller(GenFuInstance genfu) : base(genfu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_SHORT;
             Max = GenFu.Defaults.MAX_SHORT;
         }
 
-        public NullableShortFiller(Type objectType, string propertyName, short min, short max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableShortFiller(GenFuInstance genfu, Type objectType, string propertyName, short min, short max)
+            : base(genfu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -122,21 +138,24 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return (short?)GenFu.Random.Next(Min, Max);
+            return (short?)this.GenFu.Random.Next(Min, Max);
         }
     }
 
     public class NullableUShortFiller : PropertyFiller<ushort?>
     {
+        public NullableUShortFiller() : this(A.GenFuInstance) { }
 
-        public NullableUShortFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableUShortFiller(Type objectType, string propertyName, ushort min, ushort max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableUShortFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_USHORT;
             Max = GenFu.Defaults.MAX_USHORT;
         }
 
-        public NullableUShortFiller(Type objectType, string propertyName, ushort min, ushort max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableUShortFiller(GenFuInstance genFu, Type objectType, string propertyName, ushort min, ushort max)
+            : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -148,20 +167,23 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return (ushort?)GenFu.Random.Next(Min, Max);
+            return (ushort?)this.GenFu.Random.Next(Min, Max);
         }
     }
 
     public class LongFiller : PropertyFiller<long>
     {
+        public LongFiller() : this(A.GenFuInstance) { }
 
-        public LongFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public LongFiller(Type objectType, string propertyName, int min, int max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+        
+        public LongFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public LongFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public LongFiller(GenFuInstance genFu, Type objectType, string propertyName, int min, int max) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -172,20 +194,23 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return GenFu.Random.Next(Min, Max);
+            return this.GenFu.Random.Next(Min, Max);
         }
     }
 
     public class NullableLongFiller : PropertyFiller<long?>
     {
+        public NullableLongFiller() : this(A.GenFuInstance) { }
 
-        public NullableLongFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableLongFiller(Type objectType, string propertyName, int min, int max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableLongFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public NullableLongFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableLongFiller(GenFuInstance genFu, Type objectType, string propertyName, int min, int max) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -196,20 +221,23 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return new long?(GenFu.Random.Next(Min, Max));
+            return new long?(this.GenFu.Random.Next(Min, Max));
         }
     }
 
     public class NullableULongFiller : PropertyFiller<ulong?>
     {
+        public NullableULongFiller() : this(A.GenFuInstance) { }
 
-        public NullableULongFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableULongFiller(Type objectType, string propertyName, int min, int max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableULongFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = 0;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public NullableULongFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableULongFiller(GenFuInstance genFu, Type objectType, string propertyName, int min, int max) : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -220,21 +248,24 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return new ulong?((ulong)GenFu.Random.Next(Min, Max));
+            return new ulong?((ulong)this.GenFu.Random.Next(Min, Max));
         }
     }
 
     public class DecimalFiller : PropertyFiller<decimal>
     {
-        public DecimalFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public DecimalFiller() : this(A.GenFuInstance) { }
+        public DecimalFiller(Type objectType, string propertyName, decimal min, decimal max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public DecimalFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_DECIMAL;
             Max = GenFu.Defaults.MAX_DECIMAL;
         }
 
-        public DecimalFiller(Type objectType, string propertyName, decimal min, decimal max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public DecimalFiller(GenFuInstance genFu, Type objectType, string propertyName, decimal min, decimal max)
+            : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -246,8 +277,8 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            var rnd = GenFu.Random.NextDouble() - 0.5f;
-            var baseValue = GenFu.Random.Next((int)Max - (int)Min) + rnd;
+            var rnd = this.GenFu.Random.NextDouble() - 0.5f;
+            var baseValue = this.GenFu.Random.Next((int)Max - (int)Min) + rnd;
             decimal result = ((decimal)baseValue + Min) * 1.035m;
 
             if (result < Min) result += 0.5m;
@@ -259,15 +290,19 @@ namespace GenFu
 
     public class NullableDecimalFiller : PropertyFiller<decimal?>
     {
-        public NullableDecimalFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableDecimalFiller() : this(A.GenFuInstance) { }
+
+        public NullableDecimalFiller(Type objectType, string propertyName, decimal min, decimal max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableDecimalFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_DECIMAL;
             Max = GenFu.Defaults.MAX_DECIMAL;
         }
 
-        public NullableDecimalFiller(Type objectType, string propertyName, decimal min, decimal max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableDecimalFiller(GenFuInstance genFu, Type objectType, string propertyName, decimal min, decimal max)
+            : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -279,8 +314,8 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            var rnd = GenFu.Random.NextDouble() - 0.5f;
-            var baseValue = GenFu.Random.Next((int)Max - (int)Min) + rnd;
+            var rnd = this.GenFu.Random.NextDouble() - 0.5f;
+            var baseValue = this.GenFu.Random.Next((int)Max - (int)Min) + rnd;
             decimal result = ((decimal)baseValue + Min) * 1.035m;
 
             if (result < Min) result += 0.5m;
@@ -293,15 +328,18 @@ namespace GenFu
 
     public class DoubleFiller : PropertyFiller<double>
     {
+        public DoubleFiller() : this(A.GenFuInstance) { }
 
-        public DoubleFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public DoubleFiller(Type objectType, string propertyName, double min, double max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+        
+        public DoubleFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_DOUBLE;
             Max = GenFu.Defaults.MAX_DOUBLE;
         }
 
-        public DoubleFiller(Type objectType, string propertyName, double min, double max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public DoubleFiller(GenFuInstance genFu, Type objectType, string propertyName, double min, double max)
+            : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -313,21 +351,24 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return (GenFu.Random.NextDouble() * (Max-Min)) + Min;
+            return (this.GenFu.Random.NextDouble() * (Max - Min)) + Min;
         }
     }
 
     public class NullableDoubleFiller : PropertyFiller<double?>
     {
+        public NullableDoubleFiller() : this(A.GenFuInstance) { }
 
-        public NullableDoubleFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableDoubleFiller(Type objectType, string propertyName, double min, double max) : this(A.GenFuInstance, objectType, propertyName, min, max) { }
+
+        public NullableDoubleFiller(GenFuInstance genFu) : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
             Min = GenFu.Defaults.MIN_DOUBLE;
             Max = GenFu.Defaults.MAX_DOUBLE;
         }
 
-        public NullableDoubleFiller(Type objectType, string propertyName, double min, double max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableDoubleFiller(GenFuInstance genFu, Type objectType, string propertyName, double min, double max)
+            : base(genFu, new[] { objectType.FullName }, new[] { propertyName })
         {
             Min = min;
             Max = max;
@@ -339,7 +380,7 @@ namespace GenFu
 
         public override object GetValue(object instance)
         {
-            return new double?((GenFu.Random.NextDouble() * (Max - Min)) + Min);
+            return new double?((this.GenFu.Random.NextDouble() * (Max - Min)) + Min);
         }
     }
 
@@ -348,32 +389,36 @@ namespace GenFu
         private const int _minAge = 1;
         private const int _maxAge = 93;
 
-        public AgeFiller()
-            : base(new[] { "object" }, new[] { "Age" })
+        public AgeFiller() : this(A.GenFuInstance) { }
+        
+        public AgeFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "Age" })
         {
         }
 
         public override object GetValue(object instance)
         {
-            return Math.Abs(GenFu.Random.Next(_minAge, _maxAge));
+            return Math.Abs(this.GenFu.Random.Next(_minAge, _maxAge));
         }
     }
 
     public class PriceFiller : PropertyFiller<decimal>
     {
         private const int _maxPrice = 1000;
+        
+        public PriceFiller() : this(A.GenFuInstance) { }
 
-        public PriceFiller()
-            : base(new[] { "object" }, new[] { "price", "amount", "amt" })
+        public PriceFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "price", "amount", "amt" })
         {
         }
 
         public override object GetValue(object instance)
         {
 
-            decimal result = (decimal)(GenFu.Random.NextDouble() * _maxPrice);
+            decimal result = (decimal)(this.GenFu.Random.NextDouble() * _maxPrice);
 
-            return Math.Round(result,2);
+            return Math.Round(result, 2);
         }
     }
 

--- a/src/GenFu/Fillers/PersonFiller.cs
+++ b/src/GenFu/Fillers/PersonFiller.cs
@@ -9,8 +9,10 @@ namespace GenFu.Fillers
     {
         public class SexFiller : PropertyFiller<string>
         {
-            public SexFiller()
-                : base(new[] { "object" }, new[] { "sex" })
+            public SexFiller() : this(A.GenFuInstance) { }
+
+            public SexFiller(GenFuInstance genFu)
+                : base(genFu, new[] { "object" }, new[] { "sex" })
             {
             }
 
@@ -23,8 +25,10 @@ namespace GenFu.Fillers
 
          public class GenderFiller : PropertyFiller<string>
         {
-            public GenderFiller()
-                : base(new[] { "object" }, new[] { "gender" })
+            public GenderFiller() : this(A.GenFuInstance) { }
+
+            public GenderFiller(GenFuInstance genFu)
+                : base(genFu, new[] { "object" }, new[] { "gender" })
             {
             }
 

--- a/src/GenFu/Fillers/PropertyFiller.cs
+++ b/src/GenFu/Fillers/PropertyFiller.cs
@@ -10,16 +10,17 @@ namespace GenFu
         /// </summary>
         /// <param name="objectTypeNames">The names of the object types that this property filler will target</param>
         /// <param name="propertyNames">The names of the properties that this property filler will target</param>
-        protected PropertyFiller(string[] objectTypeNames, string[] propertyNames)
-            : this(objectTypeNames, propertyNames, false)
+        protected PropertyFiller(GenFuInstance genfu, string[] objectTypeNames, string[] propertyNames)
+            : this(genfu, objectTypeNames, propertyNames, false)
         {
-
+            GenFu = genfu;
         }
 
-        internal PropertyFiller(string[] objectTypeNames, string[] propertyNames, bool isGenericFiller)
+        internal PropertyFiller(GenFuInstance genfu, string[] objectTypeNames, string[] propertyNames, bool isGenericFiller)
         {
             ObjectTypeNames = objectTypeNames.Select(o => o.ToLowerInvariant()).ToArray();
             PropertyNames = propertyNames.Select(p => p.ToLowerInvariant()).ToArray();
+            GenFu = genfu;
             IsGenericFiller = isGenericFiller;
         }
 
@@ -29,7 +30,9 @@ namespace GenFu
         public bool IsGenericFiller { get; private set; }
 
         public Type PropertyType { get { return typeof(T); } }
-        
+
+        public GenFuInstance GenFu { get; }
+
         /// <summary>
         /// Returns a value that will be used to a particular property
         /// </summary>

--- a/src/GenFu/Fillers/StringFillerExtensions.cs
+++ b/src/GenFu/Fillers/StringFillerExtensions.cs
@@ -18,7 +18,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsEmailAddress<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.Email());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.Email());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -33,7 +33,7 @@ namespace GenFu
 
         public static GenFuConfigurator<T> AsEmailAddressForDomain<T>(this GenFuStringConfigurator<T> configurator, string domain) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.Email(domain));
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.Email(domain));
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -46,7 +46,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsTwitterHandle<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.Twitter());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.Twitter());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -59,7 +59,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsArticleTitle<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Names.Title());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Names.Title());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -72,7 +72,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsPhoneNumber<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.PhoneNumber());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ContactInformation.PhoneNumber());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -85,7 +85,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsFirstName<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Names.FirstName());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Names.FirstName());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -98,7 +98,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsPersonTitle<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Names.PersonTitle());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Names.PersonTitle());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -111,7 +111,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsLastName<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Names.LastName());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Names.LastName());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -124,7 +124,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsAddress<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Address.AddressLine());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu, configurator.PropertyInfo.Name, typeof(T), () => Address.AddressLine());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -137,7 +137,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsAddressLine2<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Address.AddressLine2());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Address.AddressLine2());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -150,7 +150,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsCity<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Address.City());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Address.City());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -163,7 +163,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsCanadianProvince<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Address.CanadianProvince());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Address.CanadianProvince());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -176,7 +176,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsUsaState<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => Address.UsaState());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => Address.UsaState());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -189,7 +189,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsMusicArtistName<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Music.Artist.Name());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Music.Artist.Name());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -202,7 +202,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsMusicGenreName<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Music.Genre.Name());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Music.Genre.Name());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -215,7 +215,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsMusicGenreDescription<T>(this GenFuStringConfigurator<T> configurator) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Music.Genre.Description());
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Music.Genre.Description());
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -232,7 +232,7 @@ namespace GenFu
 
         public static GenFuConfigurator<T> AsLoremIpsumWords<T>(this GenFuStringConfigurator<T> configurator, int numberOfWords = 1) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Lorem.Lorem.GenerateWords(numberOfWords));
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Lorem.Lorem.GenerateWords(numberOfWords));
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -245,7 +245,7 @@ namespace GenFu
         /// <returns>A configurator for the specified object type</returns>
         public static GenFuConfigurator<T> AsLoremIpsumSentences<T>(this GenFuStringConfigurator<T> configurator, int numberOfSentences = 1) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Lorem.Lorem.GenerateSentences(numberOfSentences));
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T), () => ValueGenerators.Lorem.Lorem.GenerateSentences(numberOfSentences));
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }
@@ -260,8 +260,8 @@ namespace GenFu
             string textColor = null,
             ImgFormat format = ImgFormat.GIF) where T : new()
         {
-            CustomFiller<string> filler = new CustomFiller<string>(configurator.PropertyInfo.Name, typeof(T), 
-                () => PlaceholditUrlBuilder.UrlFor(width,height, text ,backgroundColor,textColor, format));
+            CustomFiller<string> filler = new CustomFiller<string>(configurator.GenFu,configurator.PropertyInfo.Name, typeof(T),
+                () => PlaceholditUrlBuilder.UrlFor(width, height, text, backgroundColor, textColor, format));
             configurator.Maggie.RegisterFiller(filler);
             return configurator;
         }

--- a/src/GenFu/Fillers/StringFillers.cs
+++ b/src/GenFu/Fillers/StringFillers.cs
@@ -7,8 +7,10 @@ namespace GenFu
 {
     public class StringFiller : PropertyFiller<string>
     {
-        public StringFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public StringFiller(): this(A.GenFuInstance) { }
+
+        public StringFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "*" }, true)
         {
         }
 
@@ -19,8 +21,10 @@ namespace GenFu
     }
     public class ArticleTitleFiller : PropertyFiller<string>
     {
-        public ArticleTitleFiller()
-            : base(new[] { "object" }, new[] { "title" })
+        public ArticleTitleFiller() : this(A.GenFuInstance) { }
+
+        public ArticleTitleFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "title" })
         {
         }
 
@@ -32,8 +36,10 @@ namespace GenFu
 
     public class FirstNameFiller : PropertyFiller<string>
     {
-        public FirstNameFiller()
-            : base(new[] { "object" }, new[] { "firstname", "fname", "first_name" })
+        public FirstNameFiller() : this(A.GenFuInstance) { }
+
+        public FirstNameFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "firstname", "fname", "first_name" })
         {
         }
 
@@ -45,8 +51,10 @@ namespace GenFu
 
     public class PersonTitleFiller : PropertyFiller<string>
     {
-        public PersonTitleFiller()
-            : base(new[] { "person", "employee", "user" }, new[] { "title" })
+        public PersonTitleFiller() : this(A.GenFuInstance) { }
+
+        public PersonTitleFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "person", "employee", "user" }, new[] { "title" })
         {
         }
 
@@ -58,8 +66,10 @@ namespace GenFu
 
     public class LastNameFiller : PropertyFiller<string>
     {
-        public LastNameFiller()
-            : base(new[] { "object" }, new[] { "lastname", "lname", "last_name" })
+        public LastNameFiller() : this(A.GenFuInstance) { }
+
+        public LastNameFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "lastname", "lname", "last_name" })
         {
         }
 
@@ -71,8 +81,10 @@ namespace GenFu
 
     public class EmailFiller : PropertyFiller<string>
     {
-        public EmailFiller()
-            : base(new[] { "object" }, new[] { "email", "emailaddress", "email_address" })
+        public EmailFiller() : this(A.GenFuInstance) { }
+
+        public EmailFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "email", "emailaddress", "email_address" })
         {
         }
 
@@ -84,8 +96,10 @@ namespace GenFu
 
     public class TwitterFiller : PropertyFiller<string>
     {
-        public TwitterFiller()
-            : base(new[] { "object" }, new[] { "twitter", "twitterhandle", "twitter_handle", "twittername" })
+        public TwitterFiller(): this(A.GenFuInstance) { }
+
+        public TwitterFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "twitter", "twitterhandle", "twitter_handle", "twittername" })
         {
         }
 
@@ -97,8 +111,10 @@ namespace GenFu
 
     public class AddressFiller : PropertyFiller<string>
     {
-        public AddressFiller()
-            : base(new[] { "object" }, new[] { "address", "address1", "address_1", "billingaddress", "billing_address" })
+        public AddressFiller() : this(A.GenFuInstance) { }
+
+        public AddressFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "address", "address1", "address_1", "billingaddress", "billing_address" })
         {
         }
 
@@ -110,8 +126,10 @@ namespace GenFu
 
     public class AddressLine2Filler : PropertyFiller<string>
     {
-        public AddressLine2Filler()
-            : base(new[] { "object" }, new[] { "address2", "address_2" })
+        public AddressLine2Filler() : this(A.GenFuInstance) { }
+
+        public AddressLine2Filler(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "address2", "address_2" })
         {
         }
 
@@ -123,8 +141,10 @@ namespace GenFu
 
     public class CityFiller : PropertyFiller<string>
     {
-        public CityFiller()
-            : base(new[] { "object" }, new[] { "city", "cityname", "city_name" })
+        public CityFiller() : this(A.GenFuInstance) { }
+
+        public CityFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "city", "cityname", "city_name" })
         {
         }
 
@@ -136,8 +156,10 @@ namespace GenFu
 
     public class StateFiller : PropertyFiller<string>
     {
-        public StateFiller()
-            : base(new[] { "object" }, new[] { "state", "statename", "state_name" })
+        public StateFiller(): this(A.GenFuInstance) { }
+
+        public StateFiller(GenFuInstance genFu)
+                : base(genFu, new[] { "object" }, new[] { "state", "statename", "state_name" })
         {
         }
 
@@ -149,8 +171,10 @@ namespace GenFu
 
     public class StateAbreviationFiller : PropertyFiller<string>
     {
-        public StateAbreviationFiller()
-            : base(new[] { "object" }, new[] { "stateAbreviation" })
+        public StateAbreviationFiller() : this(A.GenFuInstance) { }
+
+        public StateAbreviationFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "stateAbreviation" })
         {
         }
 
@@ -163,8 +187,10 @@ namespace GenFu
 
     public class ProvinceFiller : PropertyFiller<string>
     {
-        public ProvinceFiller()
-            : base(new[] { "object" }, new[] { "province", "provincename", "province_name" })
+        public ProvinceFiller() : this(A.GenFuInstance) { }
+
+        public ProvinceFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "province", "provincename", "province_name" })
         {
         }
 
@@ -176,8 +202,10 @@ namespace GenFu
 
     public class ZipCodeFiller : PropertyFiller<string>
     {
-        public ZipCodeFiller()
-            : base(new[] { "object" }, new[] { "zip", "zipcode", "zip_code" })
+        public ZipCodeFiller(): this(A.GenFuInstance) { }
+
+        public ZipCodeFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "zip", "zipcode", "zip_code" })
         {
         }
 
@@ -189,8 +217,10 @@ namespace GenFu
 
     public class PostalCodeFiller : PropertyFiller<string>
     {
-        public PostalCodeFiller()
-            : base(new[] { "object" }, new[] { "postalcode", "postal_code" })
+        public PostalCodeFiller() : this(A.GenFuInstance) { }
+
+        public PostalCodeFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "postalcode", "postal_code" })
         {
         }
 
@@ -202,8 +232,10 @@ namespace GenFu
 
     public class PhoneNumberFiller : PropertyFiller<string>
     {
-        public PhoneNumberFiller()
-            : base(new[] { "object" }, new[] { "fax", "phone", "phonenumber", "phone_number", "homenumber", "worknumber" })
+        public PhoneNumberFiller() : this(A.GenFuInstance) { }
+
+        public PhoneNumberFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "fax", "phone", "phonenumber", "phone_number", "homenumber", "worknumber" })
         {
         }
 
@@ -215,8 +247,10 @@ namespace GenFu
 
     public class MusicAlbumTitleFiller : PropertyFiller<string>
     {
-        public MusicAlbumTitleFiller()
-            : base(new[] { "album", "musicalbum", "music_album" }, new[] { "title", "albumname", "name" })
+        public MusicAlbumTitleFiller() : this(A.GenFuInstance) { }
+
+        public MusicAlbumTitleFiller(GenFuInstance genfu)
+            : base(genfu, new[] { "album", "musicalbum", "music_album" }, new[] { "title", "albumname", "name" })
         {
         }
 
@@ -228,8 +262,10 @@ namespace GenFu
 
     public class MusicArtistNameFiller : PropertyFiller<string>
     {
-        public MusicArtistNameFiller()
-            : base(new[] { "artist" }, new[] { "name", "artistname", "artist_name" })
+        public MusicArtistNameFiller() : this(A.GenFuInstance) { }
+
+        public MusicArtistNameFiller(GenFuInstance genfu)
+            : base(genfu, new[] { "artist" }, new[] { "name", "artistname", "artist_name" })
         {
         }
 
@@ -241,8 +277,10 @@ namespace GenFu
 
     public class MusicGenreNameFiller : PropertyFiller<string>
     {
-        public MusicGenreNameFiller()
-            : base(new[] { "genre", "musicgenre", "music_genre" }, new[] { "title", "name", "genre_title", "genre_name" })
+        public MusicGenreNameFiller() : this(A.GenFuInstance) { }
+
+        public MusicGenreNameFiller(GenFuInstance genfu)
+            : base(genfu, new[] { "genre", "musicgenre", "music_genre" }, new[] { "title", "name", "genre_title", "genre_name" })
         {
         }
 
@@ -254,8 +292,10 @@ namespace GenFu
 
     public class MusicGenreDescriptionFiller : PropertyFiller<string>
     {
-        public MusicGenreDescriptionFiller()
-            : base(new[] { "genre", "musicgenre", "music_genre" }, new[] { "description", "desc", "genre_description", "genre_desc" })
+        public MusicGenreDescriptionFiller() : this(A.GenFuInstance) { }
+
+        public MusicGenreDescriptionFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "genre", "musicgenre", "music_genre" }, new[] { "description", "desc", "genre_description", "genre_desc" })
         {
         }
 

--- a/src/GenFu/Fillers/USASocialSecurityNumberFiller.cs
+++ b/src/GenFu/Fillers/USASocialSecurityNumberFiller.cs
@@ -7,9 +7,10 @@ namespace GenFu.Fillers
 {
     public class USASocialSecurityNumberFiller : PropertyFiller<String>
     {
+        public USASocialSecurityNumberFiller(): this(A.GenFuInstance) { }
 
-        public USASocialSecurityNumberFiller()
-            : base(new[] { "object" }, new[] { "SSN", "SocialSecurityNumber" })
+        public USASocialSecurityNumberFiller(GenFuInstance genFu)
+            : base(genFu, new[] { "object" }, new[] { "SSN", "SocialSecurityNumber" })
         { }
 
         public override object GetValue(object instance)

--- a/src/GenFu/GenFu.cs
+++ b/src/GenFu/GenFu.cs
@@ -3,45 +3,38 @@ using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
 using Angela.vNext.Reflection;
+using StaticGenfu = GenFu.GenFu;
 
 namespace GenFu
 {
-    public class A : GenFu { }
-    
-
-    public class Eh : GenFu { }
-
-    public partial class GenFu
+    public partial class GenFuInstance
     {
-        private static GenFu _genfu = new GenFu();
-        private static FillerManager _fillerManager = new FillerManager();
+        private FillerManager _fillerManager;
+        private int _listCount = StaticGenfu.Defaults.LIST_COUNT;
 
-        private static int _listCount = GenFu.Defaults.LIST_COUNT;
-
-        static GenFu()
+        public GenFuInstance()
         {
-            _fillerManager = new FillerManager();
+            _fillerManager = new FillerManager(this);
             Random = new Random();
         }
 
-        public static T New<T>() where T : new()
+        public T New<T>() where T : new()
         {
-            return (T) New(typeof(T));
+            return (T)New(typeof(T));
         }
 
-        public static object New(Type type)
+        public object New(Type type)
         {
             object instance = Activator.CreateInstance(type);
             return New(instance);
         }
 
-        public static T New<T>(T instance)
+        public T New<T>(T instance)
         {
-            return (T) New((object) instance);
-      
+            return (T)New((object)instance);
         }
 
-        public static object New(object instance)
+        public object New(object instance)
         {
             if (instance != null)
             {
@@ -69,12 +62,12 @@ namespace GenFu
         }
 
 
-        public static List<T> ListOf<T>() where T : new()
+        public List<T> ListOf<T>() where T : new()
         {
             return ListOf(typeof(T)).Cast<T>().ToList();
         }
 
-        public static List<object> ListOf(Type type)
+        public List<object> ListOf(Type type)
         {
             return BuildList(type, _listCount);
         }
@@ -84,46 +77,46 @@ namespace GenFu
         /// <typeparam name="T"></typeparam>
         /// <param name="itemCount">Number of items to add</param>
         /// <returns></returns>
-        public static List<T> ListOf<T>(int itemCount) where T : new()
+        public List<T> ListOf<T>(int itemCount) where T : new()
         {
             return ListOf(typeof(T), itemCount).Cast<T>().ToList();
         }
 
-        public static List<object> ListOf(Type type, int itemCount)
+        public List<object> ListOf(Type type, int itemCount)
         {
             return BuildList(type, itemCount);
         }
 
-        private static List<object> BuildList(Type type, int itemCount)
+        private List<object> BuildList(Type type, int itemCount)
         {
             var result = new List<object>();
 
             for (int i = 0; i < itemCount; i++)
             {
-                result.Add(GenFu.New(type));
+                result.Add(New(type));
             }
 
             return result;
         }
 
-        private static void SetPropertyValue(object instance, PropertyInfo property)
+        private void SetPropertyValue(object instance, PropertyInfo property)
         {
             IPropertyFiller filler = _fillerManager.GetFiller(property);
             property.SetValue(instance, filler.GetValue(instance), null);
         }
-        
-        private static void CallSetterMethod(object instance, MethodInfo method)
+
+        private void CallSetterMethod(object instance, MethodInfo method)
         {
             IPropertyFiller filler = _fillerManager.GetMethodFiller(method);
             if (filler != null)
-                method.Invoke(instance, new[] {filler.GetValue(instance)});
+                method.Invoke(instance, new[] { filler.GetValue(instance) });
         }
 
 
 
-        public static DateTime MinDateTime
+        public DateTime MinDateTime
         {
-            get {  return new GenericFillerDefaults(_fillerManager).GetMinDateTime(); }
+            get { return new GenericFillerDefaults(_fillerManager).GetMinDateTime(); }
 
             set
             {
@@ -131,7 +124,7 @@ namespace GenFu
             }
         }
 
-        public static DateTime MaxDateTime
+        public DateTime MaxDateTime
         {
             get { return new GenericFillerDefaults(_fillerManager).GetMaxDateTime(); }
             set
@@ -140,65 +133,11 @@ namespace GenFu
             }
         }
 
-        public static Random Random { get; private set; }
-
-        public class Defaults
-        {
-            public const int MIN_INT = 1;
-            public const int MAX_INT = 100;
-
-            public const uint MIN_UINT = 1;
-            public const uint MAX_UINT = 100;
-
-            public static double MIN_DOUBLE = 1;
-            public static double MAX_DOUBLE = 10000;
+        public Random Random { get; private set; }
 
 
-            public static short MIN_SHORT = 1;
-            public static short MAX_SHORT = Int16.MaxValue;
+        public GenFu.DefaultValues Defaults { get => _defaults; }
 
-            public static ushort MIN_USHORT = 100;
-            public static ushort MAX_USHORT = UInt16.MaxValue;
-
-
-            public const decimal MIN_DECIMAL = 0;
-            public const decimal MAX_DECIMAL = 100;
-
-            public const int LIST_COUNT = 25;
-
-            public static DateTime MIN_DATETIME = DateTime.Now.AddYears(-30);
-            public static DateTime MAX_DATETIME = DateTime.Now.AddYears(30);
-            
-            public static double SEED_PERCENTAGE = 0.2;
-
-            public const string FILE_DOMAIN_NAMES = "DomainNames";
-            public const string FILE_FIRST_NAMES = "FirstNames";
-            public const string FILE_LAST_NAMES = "LastNames";
-            public const string FILE_PERSON_TITLES = "PersonTitles";
-            public const string FILE_TITLES = "Titles";
-            public const string FILE_WORDS = "Words";
-            public const string FILE_STREET_NAMES = "StreetNames";
-            public const string FILE_CITY_NAMES = "CityNames";
-            public const string FILE_USA_STATE_NAMES = "USAStateNames";
-            public const string FILE_USA_STATE_ABREVIATIONS = "USAStateAbreviations";
-            public const string FILE_CDN_PROVINCE_NAMES = "CanadianProvinceNames";
-            public const string FILE_CDN_PROVINCE_ABREVIATIONS = "CanadianProvinceAbreviations";
-            public const string FILE_MUSIC_ARTIST = "MusicArtists";
-            public const string FILE_MUSIC_ALBUM = "MusicAlbums";
-            public const string FILE_INGREDIENTS = "Ingredients";
-            public const string FILE_COMPANY_NAMES = "CompanyNames";
-            public const string FILE_INDUSTRIES = "Industries";
-            public const string FILE_INJURIES = "Injuries";
-            public const string FILE_GENDERS = "Genders";
-            public const string FILE_DRUGS = "Drugs";
-            public const string FILE_LOREM = "Lorem";
-
-            public const string STRING_LOADFAIL = "The resource list for {0} failed to load.";
-        }
-
-
+        private GenFu.DefaultValues _defaults = new GenFu.DefaultValues();
     }
-
-
-
 }

--- a/src/GenFu/GenFuComplexPropertyConfigurator.cs
+++ b/src/GenFu/GenFuComplexPropertyConfigurator.cs
@@ -7,7 +7,7 @@ namespace GenFu
     {
         private MemberInfo _propertyInfo;
 
-        public GenFuComplexPropertyConfigurator(GenFu genfu, FillerManager fillerManager, MemberInfo propertyInfo)
+        public GenFuComplexPropertyConfigurator(GenFuInstance genfu, FillerManager fillerManager, MemberInfo propertyInfo)
             : base(genfu, fillerManager)
         {
             _propertyInfo = propertyInfo;
@@ -20,7 +20,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(IList<T2> values)
         {
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -32,7 +32,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(IEnumerable<T2> values)
         {
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -44,7 +44,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(T2[] values)
         {
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }

--- a/src/GenFu/GenFuConfigurator.cs
+++ b/src/GenFu/GenFuConfigurator.cs
@@ -7,10 +7,10 @@ namespace GenFu
 {
     public class GenFuConfigurator
     {
-        protected GenFu _genfu;
+        protected GenFuInstance _genfu;
         protected FillerManager _fillerManager;
 
-        public GenFuConfigurator(GenFu genfu, FillerManager filterManager)
+        public GenFuConfigurator(GenFuInstance genfu, FillerManager filterManager)
         {
             _genfu = genfu;
             _fillerManager = filterManager;
@@ -42,7 +42,7 @@ namespace GenFu
         public GenFuConfigurator Fill<T1, T2>(Expression<Func<T1, T2>> expression, T2 value)
         {
             PropertyInfo propertyInfo = (expression.Body as MemberExpression).Member as PropertyInfo;
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(propertyInfo.Name, typeof(T1), () => value);
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(_genfu,propertyInfo.Name, typeof(T1), () => value);
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -58,7 +58,7 @@ namespace GenFu
         public GenFuConfigurator Fill<T1, T2>(Expression<Func<T1, T2>> expression, Func<T2> filler)
         {
             PropertyInfo propertyInfo = (expression.Body as MemberExpression).Member as PropertyInfo;
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(propertyInfo.Name, typeof(T1), filler);
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(_genfu, propertyInfo.Name, typeof(T1), filler);
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -75,7 +75,7 @@ namespace GenFu
             return this;
         }
 
-        public GenFu GenFu
+        public GenFuInstance GenFu
         {
             get { return _genfu; }
         }
@@ -88,7 +88,7 @@ namespace GenFu
 
     public class GenFuConfigurator<T> : GenFuConfigurator where T : new()
     {
-        public GenFuConfigurator(GenFu genfu, FillerManager fillerManager)
+        public GenFuConfigurator(GenFuInstance genfu, FillerManager fillerManager)
             : base(genfu, fillerManager)
         {
         }
@@ -122,7 +122,7 @@ namespace GenFu
         public GenFuConfigurator<T> Fill<T2>(Expression<Func<T, T2>> expression, T2 value)
         {
             PropertyInfo propertyInfo = GetPropertyInfoFromExpression(expression);
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(propertyInfo.Name, typeof(T), () => value);
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(_genfu, propertyInfo.Name, typeof(T), () => value);
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -138,7 +138,7 @@ namespace GenFu
         public GenFuConfigurator<T> Fill<T2>(Expression<Func<T, T2>> expression, Func<T2> filler)
         {
             PropertyInfo propertyInfo = GetPropertyInfoFromExpression(expression);
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(propertyInfo.Name, typeof(T), filler);
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(_genfu, propertyInfo.Name, typeof(T), filler);
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -154,7 +154,7 @@ namespace GenFu
         public GenFuConfigurator<T> Fill<T2>(Expression<Func<T, T2>> expression, Func<T, T2> filler)
         {
             PropertyInfo propertyInfo = GetPropertyInfoFromExpression(expression);
-            CustomFiller<T, T2> customFiller = new CustomFiller<T, T2>(propertyInfo.Name, typeof(T), filler);
+            CustomFiller<T, T2> customFiller = new CustomFiller<T, T2>(_genfu, propertyInfo.Name, typeof(T), filler);
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -246,7 +246,7 @@ namespace GenFu
         public GenFuConfigurator<T> MethodFill<T2>(Expression<Action<T>> expression, Func<T2> filler)
         {
             MethodInfo methodInfo = GetMethodInfoFromExpression(expression);
-            CustomFiller<T2> customFiller = new CustomFiller<T2>(methodInfo.Name, typeof(T), filler);
+            CustomFiller<T2> customFiller = new CustomFiller<T2>(_genfu, methodInfo.Name, typeof(T), filler);
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -263,7 +263,7 @@ namespace GenFu
         {
             MethodInfo methodInfo = GetMethodInfoFromExpression(expression);
             IPropertyFiller filler = _fillerManager.GetGenericFillerForType(methodInfo.GetParameters()[0].ParameterType);
-            PropertyFiller<T2> customFiller = new CustomFiller<T2>(methodInfo.Name,  typeof(T), () => (T2)filler.GetValue(null));
+            PropertyFiller<T2> customFiller = new CustomFiller<T2>(_genfu, methodInfo.Name,  typeof(T), () => (T2)filler.GetValue(null));
             _fillerManager.RegisterFiller(customFiller);
             return new GenFuComplexPropertyConfigurator<T, T2>(_genfu, _fillerManager, methodInfo);
         }

--- a/src/GenFu/GenFuDateTimeConfigurator.cs
+++ b/src/GenFu/GenFuDateTimeConfigurator.cs
@@ -8,7 +8,7 @@ namespace GenFu
     {
         private MemberInfo _propertyInfo;
 
-        public GenFuDateTimeConfigurator(GenFu genfu, FillerManager fillerManager, MemberInfo propertyInfo)
+        public GenFuDateTimeConfigurator(GenFuInstance genfu, FillerManager fillerManager, MemberInfo propertyInfo)
             : base(genfu, fillerManager)
         {
             _propertyInfo = propertyInfo;

--- a/src/GenFu/GenFuDecimalConfigurator.cs
+++ b/src/GenFu/GenFuDecimalConfigurator.cs
@@ -6,11 +6,13 @@ namespace GenFu
 {
     public class GenFuDecimalConfigurator<T> : GenFuConfigurator<T> where T : new()
     {
+        private readonly GenFuInstance genfu;
         private MemberInfo _propertyInfo;
 
-        public GenFuDecimalConfigurator(GenFu genfu, FillerManager fillerManager, MemberInfo propertyInfo)
+        public GenFuDecimalConfigurator(GenFuInstance genfu, FillerManager fillerManager, MemberInfo propertyInfo)
             : base(genfu, fillerManager)
         {
+            this.genfu = genfu;
             _propertyInfo = propertyInfo;
         }
 
@@ -22,7 +24,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithinRange(int min, int max)
         {
-            DecimalFiller filler = new DecimalFiller(typeof(T), _propertyInfo.Name, min, max);
+            DecimalFiller filler = new DecimalFiller(genfu, typeof(T), _propertyInfo.Name, min, max);
             _fillerManager.RegisterFiller(filler);
             return this;
         }
@@ -34,7 +36,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(decimal[] values)
         {
-            CustomFiller<decimal> customFiller = new CustomFiller<decimal>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<decimal> customFiller = new CustomFiller<decimal>(genfu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -46,7 +48,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(List<decimal> values)
         {
-            CustomFiller<decimal> customFiller = new CustomFiller<decimal>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<decimal> customFiller = new CustomFiller<decimal>(genfu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -58,7 +60,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(IEnumerable<decimal> values)
         {
-            CustomFiller<decimal> customFiller = new CustomFiller<decimal>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<decimal> customFiller = new CustomFiller<decimal>(genfu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }

--- a/src/GenFu/GenFuDefaulturator.cs
+++ b/src/GenFu/GenFuDefaulturator.cs
@@ -4,10 +4,10 @@ namespace GenFu
 {
     public class GenFuDefaulturator
     {
-        protected GenFu _genfu;
+        protected GenFuInstance _genfu;
         protected FillerManager _fillerManager;
 
-        public GenFuDefaulturator(GenFu genfu, FillerManager maggie)
+        public GenFuDefaulturator(GenFuInstance genfu, FillerManager maggie)
         {
             _genfu = genfu;
             _fillerManager = maggie;
@@ -77,7 +77,7 @@ namespace GenFu
             return this;
         }
 
-        public GenFu GenFu
+        public GenFuInstance GenFu
         {
             get { return _genfu; }
         }

--- a/src/GenFu/GenFuFluent.cs
+++ b/src/GenFu/GenFuFluent.cs
@@ -3,17 +3,17 @@
 namespace GenFu
 {
     //TODO: Consider merging this partial class.  Not much here anymore
-    public partial class GenFu
+    public partial class GenFuInstance
     {
         /// <summary>
         /// Resets GenFu to default state for next generation
         /// and allows access to fluent interface.
         /// </summary>
         /// <returns></returns>
-        public static GenFuConfigurator Configure()
+        public GenFuConfigurator Configure()
         {
             Reset();
-            return new GenFuConfigurator(_genfu, _fillerManager);
+            return new GenFuConfigurator(this, _fillerManager);
         }
 
         /// <summary>
@@ -22,16 +22,16 @@ namespace GenFu
         /// </summary>
         /// <typeparam name="T">The target object type</typeparam>
         /// <returns>A configurator for the specified object type</returns>
-        public static GenFuConfigurator<T> Configure<T>() where T : new()
+        public GenFuConfigurator<T> Configure<T>() where T : new()
         {
             //see reference test: When_running_in_parallel.registrations_are_configurable
             //Reset<T>(); remove the reset to make this operation atomic, GenFuConfigurator will replace the current registration, we don't need to remove it explicitly
-            return new GenFuConfigurator<T>(_genfu, _fillerManager);
+            return new GenFuConfigurator<T>(this, _fillerManager);
         }
 
-        public static GenFuConfigurator Set()
+        public GenFuConfigurator Set()
         {
-            return new GenFuConfigurator(_genfu, _fillerManager);
+            return new GenFuConfigurator(this, _fillerManager);
         }
 
         /// <summary>
@@ -40,21 +40,21 @@ namespace GenFu
         /// </summary>
         /// <typeparam name="T">The target object type</typeparam>
         /// <returns>A configurator for the specified object type</returns>
-        public static GenFuConfigurator<T> Set<T>() where T : new()
+        public GenFuConfigurator<T> Set<T>() where T : new()
         {
-            return new GenFuConfigurator<T>(_genfu, _fillerManager);
+            return new GenFuConfigurator<T>(this, _fillerManager);
         }
 
         /// <summary>
         /// Set global defaults for GenFu
         /// </summary>
         /// <returns>The GenFu Defaulturator</returns>
-        public static GenFuDefaulturator Default()
+        public GenFuDefaulturator Default()
         {
-            return new GenFuDefaulturator(_genfu, _fillerManager);
+            return new GenFuDefaulturator(this, _fillerManager);
         }
 
-        public static void Reset()
+        public void Reset()
         {
             _fillerManager.ResetFillers();
             var defaults = new GenericFillerDefaults(_fillerManager);
@@ -62,23 +62,23 @@ namespace GenFu
             defaults.SetMinInt(GenFu.Defaults.MIN_INT);
             defaults.SetMaxInt(GenFu.Defaults.MAX_INT);
 
-            defaults.SetMinShort(GenFu.Defaults.MIN_SHORT);
-            defaults.SetMaxShort(GenFu.Defaults.MAX_SHORT);
+            defaults.SetMinShort(this.Defaults.MIN_SHORT);
+            defaults.SetMaxShort(this.Defaults.MAX_SHORT);
 
             defaults.SetMinDecimal(GenFu.Defaults.MIN_DECIMAL);
             defaults.SetMaxDecimal(GenFu.Defaults.MAX_DECIMAL);
 
             _listCount = GenFu.Defaults.LIST_COUNT;
 
-            defaults.SetMinDateTime(GenFu.Defaults.MIN_DATETIME);
-            defaults.SetMaxDateTime(GenFu.Defaults.MAX_DATETIME);
+            defaults.SetMinDateTime(this.Defaults.MIN_DATETIME);
+            defaults.SetMaxDateTime(this.Defaults.MAX_DATETIME);
 
-            defaults.SetSeedPercentage(GenFu.Defaults.SEED_PERCENTAGE);
+            defaults.SetSeedPercentage(this.Defaults.SEED_PERCENTAGE);
 
             ResourceLoader.PropertyFillers.Clear();
         }
 
-        public static void Reset<T>()
+        public void Reset<T>()
         {
             _fillerManager.ResetFillers<T>();
 

--- a/src/GenFu/GenFuIntegerConfigurator.cs
+++ b/src/GenFu/GenFuIntegerConfigurator.cs
@@ -7,7 +7,7 @@ namespace GenFu
     {
         private MemberInfo _propertyInfo;
 
-        public GenFuIntegerConfigurator(GenFu genfu, FillerManager fillerManager, MemberInfo propertyInfo)
+        public GenFuIntegerConfigurator(GenFuInstance genfu, FillerManager fillerManager, MemberInfo propertyInfo)
             : base(genfu, fillerManager)
         {
             _propertyInfo = propertyInfo;
@@ -21,11 +21,11 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithinRange(int min, int max)
         {
-            IntFiller filler = new IntFiller(typeof(T), _propertyInfo.Name, min, max);
+            IntFiller filler = new IntFiller(this.GenFu, typeof(T), _propertyInfo.Name, min, max);
             _fillerManager.RegisterFiller(filler);
             return this;
         }
-        
+
         /// <summary>
         /// Fill the target property with a random value from the specified array
         /// </summary>
@@ -33,7 +33,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(int[] values)
         {
-            CustomFiller<int> customFiller = new CustomFiller<int>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<int> customFiller = new CustomFiller<int>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -45,7 +45,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(List<int> values)
         {
-            CustomFiller<int> customFiller = new CustomFiller<int>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<int> customFiller = new CustomFiller<int>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -57,7 +57,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(IEnumerable<int> values)
         {
-            CustomFiller<int> customFiller = new CustomFiller<int>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<int> customFiller = new CustomFiller<int>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }

--- a/src/GenFu/GenFuShortConfigurator.cs
+++ b/src/GenFu/GenFuShortConfigurator.cs
@@ -5,11 +5,13 @@ namespace GenFu
 {
     public class GenFuShortConfigurator<T> : GenFuConfigurator<T> where T : new()
     {
+        private readonly GenFuInstance genfu;
         private MemberInfo _propertyInfo;
 
-        public GenFuShortConfigurator(GenFu genfu, FillerManager fillerManager, MemberInfo propertyInfo)
+        public GenFuShortConfigurator(GenFuInstance genfu, FillerManager fillerManager, MemberInfo propertyInfo)
             : base(genfu, fillerManager)
         {
+            this.genfu = genfu;
             _propertyInfo = propertyInfo;
         }
 
@@ -21,11 +23,11 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithinRange(short min, short max)
         {
-            ShortFiller filler = new ShortFiller(typeof(T), _propertyInfo.Name, min, max);
+            ShortFiller filler = new ShortFiller(this.genfu, typeof(T), _propertyInfo.Name, min, max);
             _fillerManager.RegisterFiller(filler);
             return this;
         }
-        
+
         /// <summary>
         /// Fill the target property with a random value from the specified array
         /// </summary>
@@ -33,7 +35,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(short[] values)
         {
-            CustomFiller<short> customFiller = new CustomFiller<short>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<short> customFiller = new CustomFiller<short>(genfu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -45,7 +47,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(List<short> values)
         {
-            CustomFiller<short> customFiller = new CustomFiller<short>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<short> customFiller = new CustomFiller<short>(genfu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -57,7 +59,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(IEnumerable<short> values)
         {
-            CustomFiller<short> customFiller = new CustomFiller<short>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<short> customFiller = new CustomFiller<short>(genfu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }

--- a/src/GenFu/GenFuStatic.cs
+++ b/src/GenFu/GenFuStatic.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
+using Angela.vNext.Reflection;
+
+namespace GenFu
+{
+    public abstract class A : GenFu { }
+
+
+    public abstract class Eh : GenFu { }
+
+    public abstract partial class GenFu
+    {
+        private static GenFuInstance GenFuLocal;
+        private static object locker = new object();
+        public static GenFuInstance GenFuInstance
+        {
+            get
+            {
+                if (GenFuLocal == null)
+                    lock (locker)
+                    {
+                        if (GenFuLocal == null)
+                            GenFuLocal = new GenFuInstance();
+                    }
+
+                return GenFuLocal;
+            }
+        }
+
+        public static GenFuInstance GetFiller()
+        {
+            return new GenFuInstance();
+        }
+
+        public static T New<T>() where T : new()
+        {
+            return GenFuInstance.New<T>();
+        }
+
+        public static object New(Type type)
+        {
+            return GenFuInstance.New(type);
+        }
+
+        public static T New<T>(T instance)
+        {
+            return GenFuInstance.New<T>(instance);
+        }
+
+        public static object New(object instance)
+        {
+            return GenFuInstance.New(instance);
+        }
+
+
+        public static List<T> ListOf<T>() where T : new()
+        {
+            return GenFuInstance.ListOf<T>();
+        }
+
+        public static List<object> ListOf(Type type)
+        {
+            return GenFuInstance.ListOf(type);
+        }
+        /// <summary>
+        /// Creates a new list of <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="itemCount">Number of items to add</param>
+        /// <returns></returns>
+        public static List<T> ListOf<T>(int itemCount) where T : new()
+        {
+            return GenFuInstance.ListOf<T>(itemCount);
+        }
+
+        public static List<object> ListOf(Type type, int itemCount)
+        {
+            return GenFuInstance.ListOf(type, itemCount);
+        }
+
+
+        public static DateTime MinDateTime
+        {
+            get { return GenFuInstance.MinDateTime; }
+
+            set
+            {
+                GenFuInstance.MinDateTime = value;
+            }
+        }
+
+        public static DateTime MaxDateTime
+        {
+            get { return GenFuInstance.MaxDateTime; }
+            set
+            {
+                GenFuInstance.MinDateTime = value;
+            }
+        }
+
+        public static DefaultValues Defaults { get => _defaults; }
+
+        private static DefaultValues _defaults = new DefaultValues();
+
+        public class DefaultValues
+        {
+            public int MIN_INT = 1;
+            public int MAX_INT = 100;
+
+            public uint MIN_UINT = 1;
+            public uint MAX_UINT = 100;
+
+            public double MIN_DOUBLE = 1;
+            public double MAX_DOUBLE = 10000;
+
+
+            public short MIN_SHORT = 1;
+            public short MAX_SHORT = Int16.MaxValue;
+
+            public ushort MIN_USHORT = 100;
+            public ushort MAX_USHORT = UInt16.MaxValue;
+
+
+            public decimal MIN_DECIMAL = 0;
+            public decimal MAX_DECIMAL = 100;
+
+            public int LIST_COUNT = 25;
+
+            public DateTime MIN_DATETIME = DateTime.Now.AddYears(-30);
+            public DateTime MAX_DATETIME = DateTime.Now.AddYears(30);
+
+            public double SEED_PERCENTAGE = 0.2;
+
+            public string FILE_DOMAIN_NAMES = "DomainNames";
+            public string FILE_FIRST_NAMES = "FirstNames";
+            public string FILE_LAST_NAMES = "LastNames";
+            public string FILE_PERSON_TITLES = "PersonTitles";
+            public string FILE_TITLES = "Titles";
+            public string FILE_WORDS = "Words";
+            public string FILE_STREET_NAMES = "StreetNames";
+            public string FILE_CITY_NAMES = "CityNames";
+            public string FILE_USA_STATE_NAMES = "USAStateNames";
+            public string FILE_USA_STATE_ABREVIATIONS = "USAStateAbreviations";
+            public string FILE_CDN_PROVINCE_NAMES = "CanadianProvinceNames";
+            public string FILE_CDN_PROVINCE_ABREVIATIONS = "CanadianProvinceAbreviations";
+            public string FILE_MUSIC_ARTIST = "MusicArtists";
+            public string FILE_MUSIC_ALBUM = "MusicAlbums";
+            public string FILE_INGREDIENTS = "Ingredients";
+            public string FILE_COMPANY_NAMES = "CompanyNames";
+            public string FILE_INDUSTRIES = "Industries";
+            public string FILE_INJURIES = "Injuries";
+            public string FILE_GENDERS = "Genders";
+            public string FILE_DRUGS = "Drugs";
+            public string FILE_LOREM = "Lorem";
+
+            public string STRING_LOADFAIL = "The resource list for {0} failed to load.";
+        }
+    }
+}

--- a/src/GenFu/GenFuStaticFluent.cs
+++ b/src/GenFu/GenFuStaticFluent.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace GenFu
+{
+    //TODO: Consider merging this partial class.  Not much here anymore
+    public partial class GenFu
+    {
+        /// <summary>
+        /// Resets GenFu to default state for next generation
+        /// and allows access to fluent interface.
+        /// </summary>
+        /// <returns></returns>
+        public static GenFuConfigurator Configure()
+        {
+            return GenFuInstance.Configure();
+        }
+
+        /// <summary>
+        /// Reset and configure how the specified type is populated by GenFu
+        /// NOTE: Overwrites all previous configuration
+        /// </summary>
+        /// <typeparam name="T">The target object type</typeparam>
+        /// <returns>A configurator for the specified object type</returns>
+        public static GenFuConfigurator<T> Configure<T>() where T : new()
+        {
+            return GenFuInstance.Configure<T>();
+        }
+
+        public static GenFuConfigurator Set()
+        {
+            return GenFuInstance.Set();
+        }
+
+        /// <summary>
+        /// Configure how the specified type is populated by GenFu.
+        /// NOTE: Maintains previous configuration for the specified type.
+        /// </summary>
+        /// <typeparam name="T">The target object type</typeparam>
+        /// <returns>A configurator for the specified object type</returns>
+        public static GenFuConfigurator<T> Set<T>() where T : new()
+        {
+            return GenFuInstance.Set<T>();
+        }
+
+        /// <summary>
+        /// Set global defaults for GenFu
+        /// </summary>
+        /// <returns>The GenFu Defaulturator</returns>
+        public static GenFuDefaulturator Default()
+        {
+            //TODO: MARCO RESTAURAR ESTO  ???
+            return GenFuInstance.Default();
+            //return new GenFuDefaulturator(_genfu, _fillerManager);
+        }
+
+        public static void Reset()
+        {
+            GenFuInstance.Reset();
+        }
+
+        public static void Reset<T>()
+        {
+            GenFuInstance.Reset<T>();
+        }
+
+        public void ListCount(int count)
+        {
+            GenFuInstance.ListCount(count);
+        }
+    }
+}

--- a/src/GenFu/GenFuStringConfigurator.cs
+++ b/src/GenFu/GenFuStringConfigurator.cs
@@ -7,7 +7,7 @@ namespace GenFu
     {
         private MemberInfo _propertyInfo;
 
-        public GenFuStringConfigurator(GenFu genfu, FillerManager fillerManager, MemberInfo propertyInfo)
+        public GenFuStringConfigurator(GenFuInstance genfu, FillerManager fillerManager, MemberInfo propertyInfo)
             : base(genfu, fillerManager)
         {
             _propertyInfo = propertyInfo;
@@ -20,7 +20,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(string[] values)
         {
-            CustomFiller<string> customFiller = new CustomFiller<string>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<string> customFiller = new CustomFiller<string>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -32,7 +32,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(List<string> values)
         {
-            CustomFiller<string> customFiller = new CustomFiller<string>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<string> customFiller = new CustomFiller<string>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }
@@ -44,7 +44,7 @@ namespace GenFu
         /// <returns>A configurator for the target object type</returns>
         public GenFuConfigurator<T> WithRandom(IEnumerable<string> values)
         {
-            CustomFiller<string> customFiller = new CustomFiller<string>(PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
+            CustomFiller<string> customFiller = new CustomFiller<string>(this.GenFu, PropertyInfo.Name, typeof(T), () => BaseValueGenerator.GetRandomValue(values));
             _fillerManager.RegisterFiller(customFiller);
             return this;
         }

--- a/src/GenFu/ValueGenerators/BaseValueGenerator.cs
+++ b/src/GenFu/ValueGenerators/BaseValueGenerator.cs
@@ -9,7 +9,14 @@ namespace GenFu
 
         protected static Random _random = new Random(Environment.TickCount);
 
+        public GenFuInstance GenFu { get; }
 
+        public BaseValueGenerator() { }
+
+        public BaseValueGenerator(GenFuInstance genFu)
+        {
+            GenFu = genFu;
+        }
 
         public static string Word()
         {
@@ -17,7 +24,6 @@ namespace GenFu
             int index = _random.Next(0, ResourceLoader.Data(PropertyType.Words).Count());
             return ResourceLoader.Data(PropertyType.Words)[index];
         }
-       
 
         public static T GetRandomValue<T>(T[] values)
         {

--- a/src/GenFu/ValueGenerators/Music/Genre.cs
+++ b/src/GenFu/ValueGenerators/Music/Genre.cs
@@ -7,6 +7,10 @@ namespace GenFu.ValueGenerators.Music
 
     public class Genre : BaseValueGenerator
     {
+        public Genre(GenFuInstance genfu) : base()
+        {
+        }
+
         public static string Name()
         {
             var prefixes = new string[] { "Acid ", "Jazzy ", "Fresh ", "Classic ", "Free ", "Hard ", "Electronic ", "Modern ", "Brazillian ", "Caribbean ", "African ", "Asian ", "Avant-Garde ", "Kansas City ", "Glam ", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" };

--- a/src/GenFu/ValueGenerators/Temporal/CalendarDate.cs
+++ b/src/GenFu/ValueGenerators/Temporal/CalendarDate.cs
@@ -7,13 +7,20 @@ namespace GenFu.ValueGenerators.Temporal
 {
     public class CalendarDate : BaseValueGenerator
     {
+        public CalendarDate() : base(A.GenFuInstance)
+        {
+        }
 
-        public static DateTime Date(DateTime earliestDate, DateTime latestDate)
+        public CalendarDate(GenFuInstance genfu) : base(genfu)
+        {
+        }
+
+        public DateTime Date(DateTime earliestDate, DateTime latestDate)
         {
             return DateTimeFill(earliestDate, latestDate);
         }
 
-        public static DateTime Date(DateRules rules)
+        public DateTime Date(DateRules rules)
         {
             // apply rule restrictions
             if (rules == DateRules.Within1Year)

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -361,7 +361,7 @@ namespace GenFu.Tests
 
             A
                 .Configure<BlogComment>()
-                .Fill(b => b.CommentDate, delegate () { return CalendarDate.Date(DateRules.FutureDates); });
+                .Fill(b => b.CommentDate, delegate () { return new CalendarDate().Date(DateRules.FutureDates); });
             var comments = A.ListOf<BlogComment>();
 
             foreach (var comment in comments)
@@ -408,12 +408,12 @@ namespace GenFu.Tests
 
             A
                 .Configure<BlogPost>()
-                .Fill(b => b.CreateDate, delegate () { return CalendarDate.Date(DateRules.PastDate); })
+                .Fill(b => b.CreateDate, delegate () { return new CalendarDate().Date(DateRules.PastDate); })
                 .Fill(b => b.Comments, delegate ()
                 {
                     A
                         .Set<BlogComment>()
-                        .Fill(b => b.CommentDate, delegate () { return CalendarDate.Date(DateRules.PastDate); });
+                        .Fill(b => b.CommentDate, delegate () { return new CalendarDate().Date(DateRules.PastDate); });
                     return A.ListOf<BlogComment>();
                 });
             var blogpost = A.New<BlogPost>();
@@ -462,7 +462,7 @@ namespace GenFu.Tests
                {
                    A
                       .Configure<BlogComment>()
-                      .Fill(b => b.CommentDate, delegate () { return CalendarDate.Date(DateRules.PastDate); });
+                      .Fill(b => b.CommentDate, delegate () { return new CalendarDate().Date(DateRules.PastDate); });
                    return A.ListOf<BlogComment>();
                });
             var blogposts = A.ListOf<BlogPost>();

--- a/tests/GenFu.Tests/Properties/AssemblyInfo.cs
+++ b/tests/GenFu.Tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -21,3 +22,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8ff288de-1a52-4e3c-8bee-67f30a65be51")]
+
+
+[assembly: CollectionBehavior(MaxParallelThreads = 1)]

--- a/tests/GenFu.Tests/ValueGenerators/BaseValueGeneratorTests.cs
+++ b/tests/GenFu.Tests/ValueGenerators/BaseValueGeneratorTests.cs
@@ -54,16 +54,17 @@ namespace GenFu.Tests
         [Fact]
         public void MakeDateRuleFutureIsCorrect()
         {
-            A.Reset();
-            var date = CalendarDate.Date(DateRules.FutureDates);
-            Assert.True(date > DateTime.Now);
+            var genfu = new GenFuInstance();
+            var date = new CalendarDate(genfu).Date(DateRules.FutureDates);
+            if (!(date > DateTime.Now))
+                Assert.True(date > DateTime.Now);
         }
 
         [Fact]
         public void MakeDateRulePastIsCorrect()
         {
             A.Reset();
-            var date = CalendarDate.Date(DateRules.PastDate);
+            var date = new CalendarDate().Date(DateRules.PastDate);
             Assert.True(DateTime.Now > date);
         }
 
@@ -77,7 +78,7 @@ namespace GenFu.Tests
 
             for (int i = 0; i < 1000; i++)
             {
-                var date = CalendarDate.Date(minDate, maxDate);
+                var date = new CalendarDate().Date(minDate, maxDate);
                 Assert.True(date >= minDate);
                 Assert.True(date <= maxDate);
             }

--- a/tests/GenFu.Tests/When_filling_using_plugin.cs
+++ b/tests/GenFu.Tests/When_filling_using_plugin.cs
@@ -6,8 +6,8 @@ namespace GenFu.Tests
     public class PluginPropertyFiller : PropertyFiller<string>
     {
         public const string Value = "This is the expected value";
-        public PluginPropertyFiller() : 
-            base(new []{"TestClass"}, new []{"TestProperty"})
+        public PluginPropertyFiller() :
+            base(A.GenFuInstance, new[] { "TestClass" }, new[] { "TestProperty" })
         {
         }
 

--- a/tests/GenFu.Tests/When_running_in_parallel.cs
+++ b/tests/GenFu.Tests/When_running_in_parallel.cs
@@ -10,55 +10,85 @@ namespace GenFu.Tests
         [Fact]
         public void new_instances_are_issued()
         {
+            var genfu = new GenFuInstance();
             Parallel.For(0, 10000, i =>
             {
-                A.New<Profile>();
+                genfu.New<Profile>();
             });
         }
 
         [Fact]
         public void registrations_can_be_reset()
         {
+            var genfu = new GenFuInstance();
             Parallel.For(0, 10000, i =>
                {
-                   A.New<Profile>();
-                   A.Reset();
+                   genfu.New<Profile>();
+                   genfu.Reset();
                });
         }
 
         [Fact]
         public void registrations_can_be_reset_separatelly()
         {
+            var genfu = new GenFuInstance();
             Parallel.For(0, 10000, i =>
             {
-                A.New<Profile>();
-                A.New<Person>();
-                A.Reset<Profile>();
-                A.Reset();
+                genfu.New<Profile>();
+                genfu.New<Person>();
+                genfu.Reset<Profile>();
+                genfu.Reset();
             });
         }
 
         [Fact]
         public void registrations_are_configurable()
         {
-
+            var genfu = new GenFuInstance();
             Parallel.For(0, 10000, i =>
             {
-                A.Configure<Person>().Fill(x => x.Age).WithinRange(20, 30);
-                var person = A.New<Person>();
+                genfu.Configure<Person>().Fill(x => x.Age).WithinRange(20, 30);
+                var person = genfu.New<Person>();
 
-                //There is a race condition here:
-                // --> if some other test does a Reset o register a new rule this condition will not be met. Thankfully maxParallelThreads is 1
                 Assert.True(person.Age >= 20 && person.Age <= 30);
             });
 
             Parallel.For(0, 10000, i =>
             {
-                A.Configure<Person>().Fill(x => x.Age).WithinRange(40, 50);
-                var person = A.New<Person>();
+                genfu.Configure<Person>().Fill(x => x.Age).WithinRange(40, 50);
+                var person = genfu.New<Person>();
 
                 Assert.True(person.Age >= 40 && person.Age <= 50);
             });
+        }
+
+        [Fact]
+        public void genfu_instances_dont_interfere_each_other()
+        {
+            var childGenerator = new GenFuInstance();
+            var youngGenerator = new GenFuInstance();
+
+            A.Configure<Person>().Fill(x => x.Age, () => 95); //Old style global reference
+            childGenerator.Configure<Person>().Fill(x => x.Age, () => 10); //instance #1
+            youngGenerator.Configure<Person>().Fill(x => x.Age, () => 20); //instance #2
+
+            var childAge = 0;
+            var youngAge = 0;
+            var oldAge = 0;
+
+            Parallel.For(0, 1000, i =>
+            {
+                var aged = A.New<Person>();
+                var child = childGenerator.New<Person>();
+                var young = youngGenerator.New<Person>();
+                childAge = Math.Max(child.Age, childAge);
+                youngAge = Math.Max(young.Age, youngAge);
+                oldAge = Math.Max(aged.Age, oldAge);
+            });
+
+            Assert.True(childAge == 10);
+            Assert.True(youngAge == 20);
+            Assert.True(oldAge == 95);
         }
     }
 }

--- a/tests/GenFu.Tests/When_running_in_parallel.cs
+++ b/tests/GenFu.Tests/When_running_in_parallel.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using GenFu.Tests.TestEntities;
 using Xunit;
 
@@ -58,48 +59,6 @@ namespace GenFu.Tests
 
                 Assert.True(person.Age >= 40 && person.Age <= 50);
             });
-        }
-
-
-
-        [Fact]
-        public void registration_changes_are_non_deterministic()
-        {
-            /*
-             * this is not exactly a test
-             * we demosntrate here that, while the FillerManager is thread safe, 
-             * it is not deterministic for multithreading
-             * because we have only one shared storage
-             */
-            /*
-             * THIS TEST CAN BE SAFELY DELETED 
-             */
-
-            var testOneGreaterThan100 = false;
-            var testOneSmallerThan100 = false;
-            var testTwoGreaterThan100 = false;
-            var testTwoSmallerThan100 = false;
-
-            Parallel.For(0, 1000, i =>
-            {
-                //conf #1
-                A.Configure<Person>().Fill(x => x.Id).WithinRange(200, 300);
-
-                var one = A.New<Person>();
-                testOneGreaterThan100 = testOneGreaterThan100 || one.Id > 100; //comes from conf#1 in any thread
-                testOneSmallerThan100 = testOneSmallerThan100 || one.Id < 100; //comes from conf#2 in another thread
-
-                //conf #2
-                A.Configure<Person>().Fill(x => x.Id).WithinRange(20, 30);
-
-                var two = A.New<Person>();
-                testTwoGreaterThan100 = testTwoGreaterThan100 || two.Id > 100; //comes from conf#1 in any thread
-                testTwoSmallerThan100 = testTwoSmallerThan100 || two.Id < 100; //comes from conf#2 in another thread
-            });
-
-            //if it were ran in a single thread both assertions would fail
-            Assert.True(testOneGreaterThan100 && testOneSmallerThan100); //result is not deterministic 
-            Assert.True(testTwoGreaterThan100 && testTwoSmallerThan100); //result is not deterministic 
         }
     }
 }


### PR DESCRIPTION
GenFu has been refactored to allow creation of instances. This will allow creation of specialized generators and usage in DI.

```
var childGenerator = new GenFuInstance();
var adultGenerator = new GenFuInstance();

childGenerator.Configure<Person>().Fill(x => x.Age).WithinRange(1, 10);
adultGenerator.Configure<Person>().Fill(x => x.Age).WithinRange(20, 100);
```

Classic static usage is still supported. No breaking changes, as you can see in the tests.

The only breaking change is the class CalendarDate that doesn't support static usage anymore. It could be reworked to avoid the change but that would mean having two versions of this class, the old static and a new one, that could be misleading. I think the impact for this change will be minimum, anyway.

Property fillers are overloaded to allow passing a GenFu instance. They will use the global instance when none is provided to avoid breaking changes, but I have the feeling that requiring an instance would be better for clarity.

