### PR TITLE
Fix issue with numeric fillers not respecting configuration

### DIFF
--- a/src/GenFu/Fillers/BooleanFiller.cs
+++ b/src/GenFu/Fillers/BooleanFiller.cs
@@ -12,7 +12,8 @@ namespace GenFu.Fillers
 
         }
 
-        public BooleanFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public BooleanFiller(Type objectType, string propertyName) 
+            : base( objectType, propertyName, false)
         {
 
         }
@@ -31,7 +32,8 @@ namespace GenFu.Fillers
 
         }
 
-        public NullableBooleanFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableBooleanFiller(Type objectType, string propertyName)
+            : base(objectType, propertyName, false)
         {
 
         }

--- a/src/GenFu/Fillers/BooleanFiller.cs
+++ b/src/GenFu/Fillers/BooleanFiller.cs
@@ -7,7 +7,7 @@ namespace GenFu.Fillers
     public class BooleanFiller : PropertyFiller<bool>
     {
 
-        public BooleanFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public BooleanFiller() : base(typeof(object), "*" , true)
         {
 
         }
@@ -26,7 +26,7 @@ namespace GenFu.Fillers
     public class NullableBooleanFiller : PropertyFiller<bool?>
     {
 
-        public NullableBooleanFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableBooleanFiller() : base(typeof(object), "*", true)
         {
 
         }

--- a/src/GenFu/Fillers/CharFiller.cs
+++ b/src/GenFu/Fillers/CharFiller.cs
@@ -12,7 +12,8 @@ namespace GenFu.Fillers
 
         }
 
-        public CharFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public CharFiller(Type objectType, string propertyName)
+            : base(objectType, propertyName)
         {
 
         }
@@ -31,7 +32,8 @@ namespace GenFu.Fillers
 
         }
 
-        public NullableCharFiller(Type objectType, string propertyName) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableCharFiller(Type objectType, string propertyName) 
+            : base(objectType, propertyName)
         {
 
         }

--- a/src/GenFu/Fillers/CharFiller.cs
+++ b/src/GenFu/Fillers/CharFiller.cs
@@ -7,7 +7,7 @@ namespace GenFu.Fillers
     public class CharFiller : PropertyFiller<char>
     {
 
-        public CharFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public CharFiller() : base(typeof(object), "*", true)
         {
 
         }
@@ -26,7 +26,7 @@ namespace GenFu.Fillers
     public class NullableCharFiller : PropertyFiller<char?>
     {
 
-        public NullableCharFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableCharFiller() : base(typeof(object), "*", true)
         {
 
         }

--- a/src/GenFu/Fillers/CompanyNameFiller.cs
+++ b/src/GenFu/Fillers/CompanyNameFiller.cs
@@ -7,7 +7,7 @@ namespace GenFu.Fillers
 {
     class CompanyNameFiller : PropertyFiller<string>, IPropertyFiller
     {
-        public CompanyNameFiller(): base (new[] { "company" }, new[] { "name" }, false)
+        public CompanyNameFiller(): base (new[] { "company" }, new[] { "name" })
         {}
 
         public override object GetValue(object instance)

--- a/src/GenFu/Fillers/CustomFillers.cs
+++ b/src/GenFu/Fillers/CustomFillers.cs
@@ -31,16 +31,10 @@ namespace GenFu
         private Func<T1, T2> _filler;
 
         public CustomFiller(string propertyName, Type objectType, Func<T1, T2> filler)
-            : this(propertyName, objectType, false, filler)
-        {
-        }
-
-        internal CustomFiller(string propertyName, Type objectType, bool isGeneric, Func<T1, T2> filler)
-            : base(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
+            : base(objectType, propertyName, false)
         {
             _filler = filler;
         }
-
 
         public override object GetValue(object instance)
         {

--- a/src/GenFu/Fillers/CustomFillers.cs
+++ b/src/GenFu/Fillers/CustomFillers.cs
@@ -15,26 +15,11 @@ namespace GenFu
         }
 
         internal CustomFiller(string propertyName, Type objectType, bool isGeneric, Func<T> filler)
-            : base(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
+            : base(objectType, propertyName, isGeneric)
         {
-            if (objectType != typeof(Object))
-                AddAllBaseTypes(propertyName, objectType);
             _filler = filler;
         }
 
-
-        private void AddAllBaseTypes(string propertyName, Type objectType)
-        {
-            var objectTypeNames = new List<string> { objectType.FullName };
-
-            var baseType = objectType.GetTypeInfo().BaseType;
-            while (baseType.GetProperties().Any(x => x.Name == propertyName) && baseType != typeof(Object))
-            {
-                objectTypeNames.Add(baseType.FullName);
-                baseType = baseType.GetTypeInfo().BaseType;
-            }
-            ObjectTypeNames = objectTypeNames.ToArray();
-        }
         public override object GetValue(object instance)
         {
             return _filler.Invoke();

--- a/src/GenFu/Fillers/DateTimeFillers.cs
+++ b/src/GenFu/Fillers/DateTimeFillers.cs
@@ -11,7 +11,7 @@ namespace GenFu
         public DateTime Max { get; set; } = new DateTime(2020, 12, 31);
 
         public DateTimeFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+            : base(typeof(object), "*", true)
         {
 
         }
@@ -36,7 +36,7 @@ namespace GenFu
         private Random _random = new Random();
 
         public DateTimeOffsetFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+            : base(typeof(object), "*", true)
         {
 
         }

--- a/src/GenFu/Fillers/DateTimeNullableFillers.cs
+++ b/src/GenFu/Fillers/DateTimeNullableFillers.cs
@@ -10,8 +10,7 @@ namespace GenFu
         public DateTime Max { get; set; }
         public double SeedPercentage { get; set; } = 1;
 
-        public DateTimeNullableFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+        public DateTimeNullableFiller() : base(typeof(object), "*", true)
         {
         }
 

--- a/src/GenFu/Fillers/EnumFiller.cs
+++ b/src/GenFu/Fillers/EnumFiller.cs
@@ -7,7 +7,7 @@ namespace GenFu
     {
         readonly Type _type;
         public EnumFiller(Type type)
-            : base(new[] { "object" }, new[] { "*" }, true)
+             : base(typeof(object), "*", true)
         {
             this._type = type;
         }

--- a/src/GenFu/Fillers/GuidFiller.cs
+++ b/src/GenFu/Fillers/GuidFiller.cs
@@ -5,7 +5,7 @@ namespace GenFu.Fillers
     class GuidFiller:PropertyFiller<Guid>
     {
         public GuidFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+             : base(typeof(object), "*", true)
         { }
 
         public override object GetValue(object instance)

--- a/src/GenFu/Fillers/NumericFillers.cs
+++ b/src/GenFu/Fillers/NumericFillers.cs
@@ -12,7 +12,7 @@ namespace GenFu
         }
 
         public IntFiller(Type objectType, string propertyName, int min, int max) 
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -37,7 +37,7 @@ namespace GenFu
         }
 
         public NullableIntFiller(Type objectType, string propertyName, int min, int max) 
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -62,7 +62,7 @@ namespace GenFu
         }
 
         public NullableUIntFiller(Type objectType, string propertyName, uint min, uint max) 
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -87,7 +87,7 @@ namespace GenFu
         }
 
         public ShortFiller(Type objectType, string propertyName, short min, short max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -113,7 +113,7 @@ namespace GenFu
         }
 
         public NullableShortFiller(Type objectType, string propertyName, short min, short max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -139,7 +139,7 @@ namespace GenFu
         }
 
         public NullableUShortFiller(Type objectType, string propertyName, ushort min, ushort max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -165,7 +165,7 @@ namespace GenFu
         }
 
         public LongFiller(Type objectType, string propertyName, int min, int max) 
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -240,7 +240,7 @@ namespace GenFu
         }
 
         public DecimalFiller(Type objectType, string propertyName, decimal min, decimal max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -273,7 +273,7 @@ namespace GenFu
         }
 
         public NullableDecimalFiller(Type objectType, string propertyName, decimal min, decimal max)
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -307,7 +307,7 @@ namespace GenFu
         }
 
         public DoubleFiller(Type objectType, string propertyName, double min, double max)
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;
@@ -333,7 +333,7 @@ namespace GenFu
         }
 
         public NullableDoubleFiller(Type objectType, string propertyName, double min, double max)
-            : base(objectType, propertyName, false)
+            : base(objectType, propertyName)
         {
             Min = min;
             Max = max;

--- a/src/GenFu/Fillers/NumericFillers.cs
+++ b/src/GenFu/Fillers/NumericFillers.cs
@@ -11,7 +11,8 @@ namespace GenFu
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public IntFiller(Type objectType, string propertyName, int min, int max) : base(new []{objectType.FullName}, new []{propertyName})
+        public IntFiller(Type objectType, string propertyName, int min, int max) 
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;

--- a/src/GenFu/Fillers/NumericFillers.cs
+++ b/src/GenFu/Fillers/NumericFillers.cs
@@ -5,7 +5,7 @@ namespace GenFu
     public class IntFiller : PropertyFiller<int>
     {
 
-        public IntFiller() : base(new []{"object"}, new []{"*"}, true)
+        public IntFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
@@ -30,13 +30,14 @@ namespace GenFu
     public class NullableIntFiller : PropertyFiller<int?>
     {
 
-        public NullableIntFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableIntFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public NullableIntFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableIntFiller(Type objectType, string propertyName, int min, int max) 
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -54,13 +55,14 @@ namespace GenFu
     public class NullableUIntFiller : PropertyFiller<uint?>
     {
 
-        public NullableUIntFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableUIntFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_UINT;
             Max = GenFu.Defaults.MAX_UINT;
         }
 
-        public NullableUIntFiller(Type objectType, string propertyName, uint min, uint max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableUIntFiller(Type objectType, string propertyName, uint min, uint max) 
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -78,7 +80,7 @@ namespace GenFu
     public class ShortFiller : PropertyFiller<short>
     {
 
-        public ShortFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public ShortFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_SHORT;
             Max = GenFu.Defaults.MAX_SHORT;
@@ -104,7 +106,7 @@ namespace GenFu
     public class NullableShortFiller : PropertyFiller<short?>
     {
 
-        public NullableShortFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableShortFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_SHORT;
             Max = GenFu.Defaults.MAX_SHORT;
@@ -130,7 +132,7 @@ namespace GenFu
     public class NullableUShortFiller : PropertyFiller<ushort?>
     {
 
-        public NullableUShortFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableUShortFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_USHORT;
             Max = GenFu.Defaults.MAX_USHORT;
@@ -156,13 +158,14 @@ namespace GenFu
     public class LongFiller : PropertyFiller<long>
     {
 
-        public LongFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public LongFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public LongFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public LongFiller(Type objectType, string propertyName, int min, int max) 
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -180,13 +183,14 @@ namespace GenFu
     public class NullableLongFiller : PropertyFiller<long?>
     {
 
-        public NullableLongFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableLongFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_INT;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public NullableLongFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableLongFiller(Type objectType, string propertyName, int min, int max) 
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -204,13 +208,14 @@ namespace GenFu
     public class NullableULongFiller : PropertyFiller<ulong?>
     {
 
-        public NullableULongFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableULongFiller() : base(typeof(object), "*", true)
         {
             Min = 0;
             Max = GenFu.Defaults.MAX_INT;
         }
 
-        public NullableULongFiller(Type objectType, string propertyName, int min, int max) : base(new[] { objectType.FullName }, new[] { propertyName })
+        public NullableULongFiller(Type objectType, string propertyName, int min, int max)
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -228,7 +233,7 @@ namespace GenFu
     public class DecimalFiller : PropertyFiller<decimal>
     {
         public DecimalFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+         : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_DECIMAL;
             Max = GenFu.Defaults.MAX_DECIMAL;
@@ -261,14 +266,14 @@ namespace GenFu
     public class NullableDecimalFiller : PropertyFiller<decimal?>
     {
         public NullableDecimalFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+             : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_DECIMAL;
             Max = GenFu.Defaults.MAX_DECIMAL;
         }
 
         public NullableDecimalFiller(Type objectType, string propertyName, decimal min, decimal max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -295,14 +300,14 @@ namespace GenFu
     public class DoubleFiller : PropertyFiller<double>
     {
 
-        public DoubleFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public DoubleFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_DOUBLE;
             Max = GenFu.Defaults.MAX_DOUBLE;
         }
 
         public DoubleFiller(Type objectType, string propertyName, double min, double max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;
@@ -321,14 +326,14 @@ namespace GenFu
     public class NullableDoubleFiller : PropertyFiller<double?>
     {
 
-        public NullableDoubleFiller() : base(new[] { "object" }, new[] { "*" }, true)
+        public NullableDoubleFiller() : base(typeof(object), "*", true)
         {
             Min = GenFu.Defaults.MIN_DOUBLE;
             Max = GenFu.Defaults.MAX_DOUBLE;
         }
 
         public NullableDoubleFiller(Type objectType, string propertyName, double min, double max)
-            : base(new[] { objectType.FullName }, new[] { propertyName })
+            : base(objectType, propertyName, false)
         {
             Min = min;
             Max = max;

--- a/src/GenFu/Fillers/PropertyFiller.cs
+++ b/src/GenFu/Fillers/PropertyFiller.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace GenFu
 {
@@ -16,13 +18,33 @@ namespace GenFu
 
         }
 
+        internal PropertyFiller(Type objectType, string propertyName,  bool isGeneric)
+            : this(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
+        {
+            if (objectType != typeof(Object))
+                AddAllBaseTypes(propertyName, objectType);
+        }
+
         internal PropertyFiller(string[] objectTypeNames, string[] propertyNames, bool isGenericFiller)
         {
             ObjectTypeNames = objectTypeNames.Select(o => o.ToLowerInvariant()).ToArray();
             PropertyNames = propertyNames.Select(p => p.ToLowerInvariant()).ToArray();
-            IsGenericFiller = isGenericFiller;
+            IsGenericFiller = isGenericFiller;   
         }
 
+
+        private void AddAllBaseTypes(string propertyName, Type objectType)
+        {
+            var objectTypeNames = new List<string> { objectType.FullName };
+
+            var baseType = objectType.GetTypeInfo().BaseType;
+            while (baseType.GetProperties().Any(x => x.Name == propertyName) && baseType != typeof(Object))
+            {
+                objectTypeNames.Add(baseType.FullName);
+                baseType = baseType.GetTypeInfo().BaseType;
+            }
+            ObjectTypeNames = objectTypeNames.ToArray();
+        }
 
         public string[] PropertyNames { get; private set; }
         public string[] ObjectTypeNames { get; protected set; }

--- a/src/GenFu/Fillers/PropertyFiller.cs
+++ b/src/GenFu/Fillers/PropertyFiller.cs
@@ -18,6 +18,12 @@ namespace GenFu
 
         }
 
+        /// <summary>
+        /// Creates a property filler targeting the specified object types and properties
+        /// </summary>
+        /// <param name="objectTypeNames">The names of the object types that this property filler will target</param>
+        /// <param name="propertyNames">The names of the properties that this property filler will target</param>
+
         internal PropertyFiller(Type objectType, string propertyName,  bool isGeneric)
             : this(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
         {
@@ -25,7 +31,7 @@ namespace GenFu
                 AddAllBaseTypes(propertyName, objectType);
         }
 
-        internal PropertyFiller(string[] objectTypeNames, string[] propertyNames, bool isGenericFiller)
+        private PropertyFiller(string[] objectTypeNames, string[] propertyNames, bool isGenericFiller)
         {
             ObjectTypeNames = objectTypeNames.Select(o => o.ToLowerInvariant()).ToArray();
             PropertyNames = propertyNames.Select(p => p.ToLowerInvariant()).ToArray();

--- a/src/GenFu/Fillers/PropertyFiller.cs
+++ b/src/GenFu/Fillers/PropertyFiller.cs
@@ -24,7 +24,7 @@ namespace GenFu
         /// <param name="objectTypeNames">The names of the object types that this property filler will target</param>
         /// <param name="propertyNames">The names of the properties that this property filler will target</param>
 
-        internal PropertyFiller(Type objectType, string propertyName,  bool isGeneric)
+        internal PropertyFiller(Type objectType, string propertyName,  bool isGeneric = false)
             : this(new[] { objectType.FullName }, new[] { propertyName }, isGeneric)
         {
             if (objectType != typeof(Object))

--- a/src/GenFu/Fillers/StringFillerExtensions.cs
+++ b/src/GenFu/Fillers/StringFillerExtensions.cs
@@ -1,9 +1,6 @@
 using GenFu.Fillers;
 using GenFu.ValueGenerators.Geospatial;
 using GenFu.ValueGenerators.People;
-using System;
-using System.Text;
-using GenFu.Utilities;
 using GenFu.Services;
 
 namespace GenFu

--- a/src/GenFu/Fillers/StringFillers.cs
+++ b/src/GenFu/Fillers/StringFillers.cs
@@ -8,7 +8,7 @@ namespace GenFu
     public class StringFiller : PropertyFiller<string>
     {
         public StringFiller()
-            : base(new[] { "object" }, new[] { "*" }, true)
+             : base(typeof(object), "*", true)
         {
         }
 

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -128,7 +128,7 @@ namespace GenFu.Tests
         }
 
         [Fact]
-        public void IntRangeWithinBoundsOnGeneratedValueForComplexConfiguration()
+        public void IntRangeWithinBoundsOnGeneratedValueForPropertyOnBaseClass()
         {
             var success = true;
             A.Reset();
@@ -137,12 +137,6 @@ namespace GenFu.Tests
             {
                 A.Configure<ApplicationUser>()
                        .Fill(q => q.AccessFailedCount).WithinRange(0, 3)
-                       .Fill(q => q.Email, q => { return string.Format("{0}.{1}@gmail.com", q.UserName, q.PhoneNumber); })
-                       .Fill(q => q.PhoneNumber, "905384811896")
-                       .Fill(q => q.CreatedAt, DateTime.Now)
-                       .Fill(q => q.Gender, Gender.Female)
-                       .Fill(q => q.EmailConfirmed, true)
-                       .Fill(q => q.PhoneNumberConfirmed, true)
                        .Fill(q => q.Id, new Guid("FFC42A97-C75D-4F8B-85D7-9044BE829755"));
                 var user = A.New<ApplicationUser>();
 

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -128,6 +128,31 @@ namespace GenFu.Tests
         }
 
         [Fact]
+        public void IntRangeWithinBoundsOnGeneratedValueForComplexConfiguration()
+        {
+            var success = true;
+            A.Reset();
+
+            for (int i = 0; i < 500; i++)
+            {
+                A.Configure<ApplicationUser>()
+                       .Fill(q => q.AccessFailedCount).WithinRange(0, 3)
+                       .Fill(q => q.Email, q => { return string.Format("{0}.{1}@gmail.com", q.UserName, q.PhoneNumber); })
+                       .Fill(q => q.PhoneNumber, "905384811896")
+                       .Fill(q => q.CreatedAt, DateTime.Now)
+                       .Fill(q => q.Gender, Gender.Female)
+                       .Fill(q => q.EmailConfirmed, true)
+                       .Fill(q => q.PhoneNumberConfirmed, true)
+                       .Fill(q => q.Id, new Guid("FFC42A97-C75D-4F8B-85D7-9044BE829755"));
+                var user = A.New<ApplicationUser>();
+
+                success = (user.AccessFailedCount>= 0 && user.AccessFailedCount <= 3);
+
+                Assert.True(success);
+            }
+        }
+
+        [Fact]
         public void IntRangeWithinBoundsOnGeneratedValue()
         {
             var success = true;

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -140,7 +140,7 @@ namespace GenFu.Tests
                        .Fill(q => q.Id, new Guid("FFC42A97-C75D-4F8B-85D7-9044BE829755"));
                 var user = A.New<ApplicationUser>();
 
-                success = (user.AccessFailedCount>= 0 && user.AccessFailedCount <= 3);
+                success = (user.AccessFailedCount >= 0 && user.AccessFailedCount <= 3);
 
                 Assert.True(success);
             }
@@ -306,6 +306,20 @@ namespace GenFu.Tests
         {
             var post = A.New<BlogPost>();
             Assert.True(post.CreateDate != default(DateTime));
+        }
+
+        [Fact]
+        public void DateTimesInFutureForPropertyOnBaseClass()
+        {
+            for (int i = 0; i < 500; i++)
+            {
+                A.Configure<ApplicationUser>()
+                    .Fill(a => a.CreatedOn).AsFutureDate();
+
+                var user = A.New<ApplicationUser>();
+
+                Assert.True(user.CreatedOn > DateTime.Now);
+            }
         }
 
         [Fact]

--- a/tests/GenFu.Tests/TestEntities/ApplicationUser.cs
+++ b/tests/GenFu.Tests/TestEntities/ApplicationUser.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GenFu.Tests.TestEntities
+{
+    public class ApplicationUserBase 
+    {
+        public Guid Id { get; set; }
+
+        public int AccessFailedCount { get; set; }
+    }
+
+    public class ApplicationUser : ApplicationUserBase
+    {
+        public string UserName { get; set; }
+
+        public string PhoneNumber { get; set; }
+        public string Email { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+        public Gender Gender { get; set; }
+        public bool EmailConfirmed { get; set; }
+        public bool PhoneNumberConfirmed { get; set; }
+    }
+}

--- a/tests/GenFu.Tests/TestEntities/ApplicationUser.cs
+++ b/tests/GenFu.Tests/TestEntities/ApplicationUser.cs
@@ -7,6 +7,8 @@ namespace GenFu.Tests.TestEntities
         public Guid Id { get; set; }
 
         public int AccessFailedCount { get; set; }
+
+        public DateTime CreatedOn { get; set; }
     }
 
     public class ApplicationUser : ApplicationUserBase

--- a/tests/GenFu.Tests/TestEntities/ApplicationUser.cs
+++ b/tests/GenFu.Tests/TestEntities/ApplicationUser.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GenFu.Tests.TestEntities
 {
@@ -14,13 +12,5 @@ namespace GenFu.Tests.TestEntities
     public class ApplicationUser : ApplicationUserBase
     {
         public string UserName { get; set; }
-
-        public string PhoneNumber { get; set; }
-        public string Email { get; set; }
-
-        public DateTime CreatedAt { get; set; }
-        public Gender Gender { get; set; }
-        public bool EmailConfirmed { get; set; }
-        public bool PhoneNumberConfirmed { get; set; }
     }
 }

--- a/tests/GenFu.Tests/TestEntities/Gender.cs
+++ b/tests/GenFu.Tests/TestEntities/Gender.cs
@@ -1,0 +1,9 @@
+﻿namespace GenFu.Tests.TestEntities
+{
+    public enum Gender
+    {
+        Male,
+        Female,
+        NotSpecified
+    }
+}

--- a/tests/GenFu.Tests/When_filling_using_plugin.cs
+++ b/tests/GenFu.Tests/When_filling_using_plugin.cs
@@ -7,7 +7,7 @@ namespace GenFu.Tests
     {
         public const string Value = "This is the expected value";
         public PluginPropertyFiller() : 
-            base(new []{"TestClass"}, new []{"TestProperty"})
+            base(typeof(TestClass), "TestProperty")
         {
         }
 


### PR DESCRIPTION
Turns out the way we registered some property fillers didn't work for properties that were defined in a base class. 