### PR TITLE
Add netstandard2.0 as a new target

### DIFF
--- a/src/GenFu.HtmlHelpers/GenFu.HtmlHelpers.csproj
+++ b/src/GenFu.HtmlHelpers/GenFu.HtmlHelpers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
     <AssemblyName>GenFu.HtmlHelpers</AssemblyName>
     <PackageId>GenFu.HtmlHelpers.Wireframes</PackageId>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>

--- a/src/GenFu/GenFu.csproj
+++ b/src/GenFu/GenFu.csproj
@@ -5,7 +5,7 @@
     <Summary>GenFu is composed of several property fillers that can populate commonly named properties through reflection using an internal database of values or randomly created data. You can override any of the fillers and give GenFu hints on how to fill properties.</Summary>
     <Copyright>Please see license information on project site for more information. Ninja designed by Ridzal Zainal from the thenounproject.com</Copyright>
     <Authors>misterjames;dpaquette;stimms</Authors>
-    <TargetFrameworks>netstandard1.3;net45;net46;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net46;net461</TargetFrameworks>
     <AssemblyName>GenFu</AssemblyName>
     <PackageId>GenFu</PackageId>
     <PackageTags>.NET Test Data Generation Fake Sample ASP.NET Core</PackageTags>
@@ -24,6 +24,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <Version>1.6.0</Version>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />


### PR DESCRIPTION
Microsoft docs recommend also supporting netstandard2.0 in addition to or instead of netstandard1.x to reduce package downloads. This also reduces potential conflict surface area in netframework projects. 

"However, targeting lower .NET Standard versions introduces a number of support dependencies. If your project targets .NET Standard 1.x, we recommend that you also target .NET Standard 2.0. This simplifies the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks, and it reduces the number of packages they need to download." - https://docs.microsoft.com/en-us/dotnet/standard/net-standard#which-net-standard-version-to-target