### PR TITLE
Added LazyOf and ForeverOf

### DIFF
--- a/src/GenFu/GenFu.cs
+++ b/src/GenFu/GenFu.cs
@@ -106,6 +106,59 @@ namespace GenFu
             return result;
         }
 
+        public static IEnumerable<T> LazyOf<T>() where T : new()
+        {
+            return LazyOf(typeof(T)).Cast<T>();
+        }
+
+        public static IEnumerable<object> LazyOf(Type type)
+        {
+            return BuildLazy(type, _listCount);
+        }
+
+        /// <summary>
+        /// Creates a new lazy collection of <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="itemCount">Number of items to add</param>
+        /// <returns></returns>
+        public static IEnumerable<T> LazyOf<T>(int itemCount) where T : new()
+        {
+            return LazyOf(typeof(T), itemCount).Cast<T>();
+        }
+
+        private static IEnumerable<object> LazyOf(Type type, int itemCount)
+        {
+            return BuildLazy(type, itemCount);
+        }
+
+
+        private static IEnumerable<object> BuildLazy(Type type, int itemCount)
+        {
+            for (int i = 0; i < itemCount; i++)
+            {
+                yield return GenFu.New(type);
+            }
+        }
+
+        public static IEnumerable<T> ForeverOf<T>() where T : new()
+        {
+            return ForeverOf(typeof(T)).Cast<T>();
+        }
+
+        private static IEnumerable<object> ForeverOf(Type type)
+        {
+            return BuildForever(type);
+        }
+
+        private static IEnumerable<object> BuildForever(Type type)
+        {
+            while (true)
+            {
+                yield return GenFu.New(type);
+            }
+        }
+
         private static void SetPropertyValue(object instance, PropertyInfo property)
         {
             IPropertyFiller filler = _fillerManager.GetFiller(property);

--- a/tests/GenFu.Tests/GenFuTests.cs
+++ b/tests/GenFu.Tests/GenFuTests.cs
@@ -265,6 +265,23 @@ namespace GenFu.Tests
         }
 
         [Fact]
+        public void LazyOfDefaultGenerates25Entries()
+        {
+            var people = A.LazyOf<Person>();
+
+            Assert.Equal(A.Defaults.LIST_COUNT, people.Count());
+        }
+
+        [Fact]
+        public void LazyOfGeneratesCorrectNumberOfEntries()
+        {
+            var personCount = 17;
+            var people = A.LazyOf<Person>(personCount);
+            Assert.Equal(people.Count(), personCount);
+        }
+
+
+        [Fact]
         public void ListOfGeneratesCorrectNumberOfEntries()
         {
             var personCount = 17;


### PR DESCRIPTION
I use big fake data generation very often. The ListOf method uses a regular list and is therefore very memory-hungry.

That's why I added a few methods to generate lazy collections:
- _LazyOf<T>(int itemCount)_ for lazy generate specified count of <T> items.
- _ForeverOf<T>()_ for lazy generate infinitity count of <T> items.

I think this could be of use to a lot of developers.  I'll be happy for the merge my pull request.